### PR TITLE
Fix yargs reserved word conflict for --version option

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/link-foundation/lino-objects-codec/issues/22
+Your prepared branch: issue-22-e5ea3b44ef6b
+Your prepared working directory: /tmp/gh-issue-solver-1767898389066
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/link-foundation/lino-objects-codec/issues/22
-Your prepared branch: issue-22-e5ea3b44ef6b
-Your prepared working directory: /tmp/gh-issue-solver-1767898389066
-
-Proceed.

--- a/csharp/scripts/create-github-release.mjs
+++ b/csharp/scripts/create-github-release.mjs
@@ -28,6 +28,7 @@ const { makeConfig } = await use('lino-arguments');
 const config = makeConfig({
   yargs: ({ yargs, getenv }) =>
     yargs
+      .version(false) // Disable yargs built-in --version to use our custom version option
       .option('version', {
         type: 'string',
         default: getenv('VERSION', ''),

--- a/docs/case-studies/issue-22/README.md
+++ b/docs/case-studies/issue-22/README.md
@@ -1,0 +1,139 @@
+# Case Study: Rust CI/CD Failure - Yargs Reserved Word Conflict
+
+**Issue:** [#22](https://github.com/link-foundation/lino-objects-codec/issues/22)
+**Date of Failure:** 2026-01-08
+**CI Run:** [#20828012412](https://github.com/link-foundation/lino-objects-codec/actions/runs/20828012412/job/59834479617)
+
+## Executive Summary
+
+The Rust CI/CD pipeline was failing during the "Auto Release" phase because the `create-github-release.mjs` script was unable to parse the `--version` command-line argument. The root cause was that `"version"` is a reserved word in yargs (the CLI argument parsing library used by `lino-arguments`), which caused the argument to be interpreted as yargs' built-in version display command instead of our custom option.
+
+## Timeline of Events
+
+1. **18:48:47 UTC** - CI pipeline triggered by push to main branch
+2. **18:48:51 UTC** - "Detect Changes" job completed successfully
+3. **18:48:58 - 18:49:48 UTC** - "Lint and Format Check", "Test", and "Build Package" jobs completed successfully
+4. **18:50:06 UTC** - "Auto Release" job started
+5. **18:50:11 UTC** - Git configured, changelog fragments detected (1 fragment, patch bump)
+6. **18:50:11 UTC** - Version check passed (new version 0.2.0 detected)
+7. **18:50:19 UTC** - Build and publish steps completed
+8. **18:50:19 UTC** - "Create GitHub Release" step started
+9. **18:50:24 UTC** - **FAILURE**: Script exited with "Missing required arguments"
+
+## Root Cause Analysis
+
+### The Error
+
+```
+Auto Release	Create GitHub Release	Error: Missing required arguments
+Auto Release	Create GitHub Release	Usage: node scripts/create-github-release.mjs --version <version> --repository <repository>
+Auto Release	Create GitHub Release	##[error]Process completed with exit code 1.
+```
+
+### The Command Executed
+
+```bash
+node scripts/create-github-release.mjs \
+  --version "0.2.0" \
+  --repository "link-foundation/lino-objects-codec" \
+  --tag-prefix "rust-v"
+```
+
+### Investigation
+
+The arguments were correctly passed to the script, but the script reported "Missing required arguments". This was puzzling because the arguments were clearly present in the command.
+
+Upon testing locally, we discovered that the parsed `version` value was `false` instead of `"0.2.0"`:
+
+```javascript
+Parsed config: {
+  "version": false,  // Expected: "0.2.0"
+  "repository": "test/repo",
+  "tagPrefix": "v"
+}
+```
+
+Node.js also printed a warning:
+
+```
+Warning: "version" is a reserved word.
+Please do one of the following:
+- Disable version with `yargs.version(false)` if using "version" as an option
+- Use the built-in `yargs.version` method instead (if applicable)
+- Use a different option key
+```
+
+### Root Cause
+
+The `lino-arguments` library uses [yargs](https://yargs.js.org/) internally for CLI argument parsing. In yargs v17.2.0+, `--version` is a reserved command that displays the application version and exits. When a user defines a custom `version` option, yargs exhibits unexpected behavior - it returns `false` instead of the actual argument value.
+
+This is a known issue documented in:
+- [yargs/yargs#2064](https://github.com/yargs/yargs/issues/2064)
+- [CycloneDX/cdxgen#83](https://github.com/CycloneDX/cdxgen/issues/83)
+
+## Solution
+
+The fix is to call `.version(false)` on the yargs instance before defining the custom `version` option. This disables yargs' built-in `--version` handling and allows the custom option to be parsed correctly.
+
+### Before (Broken)
+
+```javascript
+const config = makeConfig({
+  yargs: ({ yargs, getenv }) =>
+    yargs
+      .option('version', {
+        type: 'string',
+        default: getenv('VERSION', ''),
+        describe: 'Version number (e.g., 1.0.0)',
+      })
+      // ... other options
+});
+```
+
+### After (Fixed)
+
+```javascript
+const config = makeConfig({
+  yargs: ({ yargs, getenv }) =>
+    yargs
+      .version(false) // Disable yargs built-in --version handling
+      .option('version', {
+        type: 'string',
+        default: getenv('VERSION', ''),
+        describe: 'Version number (e.g., 1.0.0)',
+      })
+      // ... other options
+});
+```
+
+## Affected Files
+
+Three scripts were affected by this issue:
+
+1. `rust/scripts/create-github-release.mjs` - **Primary failure point**
+2. `rust/scripts/collect-changelog.mjs`
+3. `csharp/scripts/create-github-release.mjs`
+
+## Lessons Learned
+
+1. **Reserved Words in Libraries**: When using CLI parsing libraries like yargs, be aware of reserved words that may conflict with your option names. Common reserved words in yargs include `version`, `help`, `$0`.
+
+2. **Warning Messages**: Node.js and libraries often emit warnings before errors occur. In this case, the warning about "version" being a reserved word was available but not visible in the CI output until the failure occurred.
+
+3. **Local Testing**: Testing scripts locally with the same arguments used in CI can help identify argument parsing issues that aren't obvious from CI logs alone.
+
+4. **Error Messages Can Be Misleading**: The error "Missing required arguments" suggested the arguments weren't being passed, but the real issue was that they were being ignored due to a naming conflict.
+
+## Prevention Measures
+
+1. **Avoid Reserved Names**: Consider using alternative option names like `pkg-version`, `release-version`, or `ver` to avoid conflicts with reserved words.
+
+2. **Always Use `.version(false)`**: When defining a custom `version` option in yargs, always disable the built-in version handling first.
+
+3. **Add Integration Tests**: Create tests that verify the CLI scripts correctly parse all expected arguments.
+
+## References
+
+- [Yargs Documentation - version()](https://yargs.js.org/docs/#api-reference-version)
+- [yargs/yargs#2064 - Cannot have version as both option and command](https://github.com/yargs/yargs/issues/2064)
+- [CycloneDX/cdxgen#83 - Warning: "version" is a reserved word](https://github.com/CycloneDX/cdxgen/issues/83)

--- a/docs/case-studies/issue-22/ci-run-20828012412.txt
+++ b/docs/case-studies/issue-22/ci-run-20828012412.txt
@@ -1,0 +1,2860 @@
+Detect Changes	Set up job	﻿2026-01-08T18:48:47.9178923Z Current runner version: '2.330.0'
+Detect Changes	Set up job	2026-01-08T18:48:47.9215591Z ##[group]Runner Image Provisioner
+Detect Changes	Set up job	2026-01-08T18:48:47.9217340Z Hosted Compute Agent
+Detect Changes	Set up job	2026-01-08T18:48:47.9218268Z Version: 20251211.462
+Detect Changes	Set up job	2026-01-08T18:48:47.9219273Z Commit: 6cbad8c2bb55d58165063d031ccabf57e2d2db61
+Detect Changes	Set up job	2026-01-08T18:48:47.9220595Z Build Date: 2025-12-11T16:28:49Z
+Detect Changes	Set up job	2026-01-08T18:48:47.9221714Z Worker ID: {e778005b-0acd-4a64-95ea-b5f629713e34}
+Detect Changes	Set up job	2026-01-08T18:48:47.9223364Z ##[endgroup]
+Detect Changes	Set up job	2026-01-08T18:48:47.9224296Z ##[group]Operating System
+Detect Changes	Set up job	2026-01-08T18:48:47.9225274Z Ubuntu
+Detect Changes	Set up job	2026-01-08T18:48:47.9226162Z 24.04.3
+Detect Changes	Set up job	2026-01-08T18:48:47.9226931Z LTS
+Detect Changes	Set up job	2026-01-08T18:48:47.9227731Z ##[endgroup]
+Detect Changes	Set up job	2026-01-08T18:48:47.9228664Z ##[group]Runner Image
+Detect Changes	Set up job	2026-01-08T18:48:47.9229732Z Image: ubuntu-24.04
+Detect Changes	Set up job	2026-01-08T18:48:47.9230528Z Version: 20260105.202.1
+Detect Changes	Set up job	2026-01-08T18:48:47.9233048Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20260105.202/images/ubuntu/Ubuntu2404-Readme.md
+Detect Changes	Set up job	2026-01-08T18:48:47.9235521Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20260105.202
+Detect Changes	Set up job	2026-01-08T18:48:47.9237662Z ##[endgroup]
+Detect Changes	Set up job	2026-01-08T18:48:47.9242266Z ##[group]GITHUB_TOKEN Permissions
+Detect Changes	Set up job	2026-01-08T18:48:47.9245795Z Actions: write
+Detect Changes	Set up job	2026-01-08T18:48:47.9246696Z ArtifactMetadata: write
+Detect Changes	Set up job	2026-01-08T18:48:47.9247852Z Attestations: write
+Detect Changes	Set up job	2026-01-08T18:48:47.9248756Z Checks: write
+Detect Changes	Set up job	2026-01-08T18:48:47.9249662Z Contents: write
+Detect Changes	Set up job	2026-01-08T18:48:47.9250629Z Deployments: write
+Detect Changes	Set up job	2026-01-08T18:48:47.9251658Z Discussions: write
+Detect Changes	Set up job	2026-01-08T18:48:47.9252813Z Issues: write
+Detect Changes	Set up job	2026-01-08T18:48:47.9253861Z Metadata: read
+Detect Changes	Set up job	2026-01-08T18:48:47.9254766Z Models: read
+Detect Changes	Set up job	2026-01-08T18:48:47.9255555Z Packages: write
+Detect Changes	Set up job	2026-01-08T18:48:47.9256496Z Pages: write
+Detect Changes	Set up job	2026-01-08T18:48:47.9257383Z PullRequests: write
+Detect Changes	Set up job	2026-01-08T18:48:47.9258438Z RepositoryProjects: write
+Detect Changes	Set up job	2026-01-08T18:48:47.9259535Z SecurityEvents: write
+Detect Changes	Set up job	2026-01-08T18:48:47.9260404Z Statuses: write
+Detect Changes	Set up job	2026-01-08T18:48:47.9261205Z ##[endgroup]
+Detect Changes	Set up job	2026-01-08T18:48:47.9264734Z Secret source: Actions
+Detect Changes	Set up job	2026-01-08T18:48:47.9266236Z Prepare workflow directory
+Detect Changes	Set up job	2026-01-08T18:48:47.9829260Z Prepare all required actions
+Detect Changes	Set up job	2026-01-08T18:48:47.9886637Z Getting action download info
+Detect Changes	Set up job	2026-01-08T18:48:48.2244535Z Download action repository 'actions/checkout@v4' (SHA:34e114876b0b11c390a56381ad16ebd13914f8d5)
+Detect Changes	Set up job	2026-01-08T18:48:48.3413465Z Download action repository 'actions/setup-node@v4' (SHA:49933ea5288caeca8642d1e84afbd3f7d6820020)
+Detect Changes	Set up job	2026-01-08T18:48:48.5315365Z Complete job name: Detect Changes
+Detect Changes	Run actions/checkout@v4	﻿2026-01-08T18:48:48.5987276Z ##[group]Run actions/checkout@v4
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:48.5988122Z with:
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:48.5988503Z   fetch-depth: 0
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:48.5988972Z   repository: link-foundation/lino-objects-codec
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:48.5989676Z   token: ***
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:48.5990049Z   ssh-strict: true
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:48.5990436Z   ssh-user: git
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:48.5990817Z   persist-credentials: true
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:48.5991256Z   clean: true
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:48.5991642Z   sparse-checkout-cone-mode: true
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:48.5992108Z   fetch-tags: false
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:48.5992696Z   show-progress: true
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:48.5993105Z   lfs: false
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:48.5993494Z   submodules: false
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:48.5993912Z   set-safe-directory: true
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:48.5994592Z env:
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:48.5994963Z   CARGO_TERM_COLOR: always
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:48.5995422Z   RUSTFLAGS: -Dwarnings
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:48.5995832Z ##[endgroup]
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:48.7048633Z Syncing repository: link-foundation/lino-objects-codec
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:48.7050451Z ##[group]Getting Git version info
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:48.7051256Z Working directory is '/home/runner/work/lino-objects-codec/lino-objects-codec'
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:48.7052294Z [command]/usr/bin/git version
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:48.7136519Z git version 2.52.0
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:48.7161775Z ##[endgroup]
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:48.7175449Z Temporarily overriding HOME='/home/runner/work/_temp/c8313bdf-a8df-4275-8ac8-146e9105287a' before making global git config changes
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:48.7176829Z Adding repository directory to the temporary git global config as a safe directory
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:48.7180306Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/lino-objects-codec/lino-objects-codec
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:48.7219435Z Deleting the contents of '/home/runner/work/lino-objects-codec/lino-objects-codec'
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:48.7222915Z ##[group]Initializing the repository
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:48.7226896Z [command]/usr/bin/git init /home/runner/work/lino-objects-codec/lino-objects-codec
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:48.7343106Z hint: Using 'master' as the name for the initial branch. This default branch name
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:48.7344639Z hint: will change to "main" in Git 3.0. To configure the initial branch name
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:48.7346232Z hint: to use in all of your new repositories, which will suppress this warning,
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:48.7347515Z hint: call:
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:48.7348117Z hint:
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:48.7348872Z hint: 	git config --global init.defaultBranch <name>
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:48.7349783Z hint:
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:48.7350384Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:48.7351264Z hint: 'development'. The just-created branch can be renamed via this command:
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:48.7351949Z hint:
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:48.7352318Z hint: 	git branch -m <name>
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:48.7353223Z hint:
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:48.7353954Z hint: Disable this message with "git config set advice.defaultBranchName false"
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:48.7355378Z Initialized empty Git repository in /home/runner/work/lino-objects-codec/lino-objects-codec/.git/
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:48.7359587Z [command]/usr/bin/git remote add origin https://github.com/link-foundation/lino-objects-codec
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:48.7391933Z ##[endgroup]
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:48.7392875Z ##[group]Disabling automatic garbage collection
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:48.7395896Z [command]/usr/bin/git config --local gc.auto 0
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:48.7423426Z ##[endgroup]
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:48.7424097Z ##[group]Setting up auth
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:48.7429827Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:48.7458694Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:48.7804799Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:48.7835063Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:48.8049726Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:48.8079859Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:48.8298638Z [command]/usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:48.8331073Z ##[endgroup]
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:48.8331861Z ##[group]Fetching the repository
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:48.8339760Z [command]/usr/bin/git -c protocol.version=2 fetch --prune --no-recurse-submodules origin +refs/heads/*:refs/remotes/origin/* +refs/tags/*:refs/tags/*
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:49.0916446Z From https://github.com/link-foundation/lino-objects-codec
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:49.0917969Z  * [new branch]      issue-1-843d779c4cdb  -> origin/issue-1-843d779c4cdb
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:49.0918932Z  * [new branch]      issue-11-c74c0836aeba -> origin/issue-11-c74c0836aeba
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:49.0919754Z  * [new branch]      issue-15-b28422959bc5 -> origin/issue-15-b28422959bc5
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:49.0920534Z  * [new branch]      issue-17-ace5a094a724 -> origin/issue-17-ace5a094a724
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:49.0921325Z  * [new branch]      issue-20-d21ab54e8ff1 -> origin/issue-20-d21ab54e8ff1
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:49.0922097Z  * [new branch]      issue-3-397c5eeac29f  -> origin/issue-3-397c5eeac29f
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:49.0923284Z  * [new branch]      issue-5-9641b6fb00d3  -> origin/issue-5-9641b6fb00d3
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:49.0924063Z  * [new branch]      issue-7-7a98520cd689  -> origin/issue-7-7a98520cd689
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:49.0924823Z  * [new branch]      issue-8-8f8d9acce5f1  -> origin/issue-8-8f8d9acce5f1
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:49.0925592Z  * [new branch]      issue-9-bef9e95e65ef  -> origin/issue-9-bef9e95e65ef
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:49.0926287Z  * [new branch]      main                  -> origin/main
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:49.0926895Z  * [new tag]         v0.1.1                -> v0.1.1
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:49.0927462Z  * [new tag]         v0.3.0                -> v0.3.0
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:49.0970455Z [command]/usr/bin/git branch --list --remote origin/main
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:49.0995337Z   origin/main
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:49.1004178Z [command]/usr/bin/git rev-parse refs/remotes/origin/main
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:49.1023863Z c79c77d68a90cadbd439c9613a7050501095c92d
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:49.1028713Z ##[endgroup]
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:49.1029782Z ##[group]Determining the checkout info
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:49.1030998Z ##[endgroup]
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:49.1034135Z [command]/usr/bin/git sparse-checkout disable
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:49.1072240Z [command]/usr/bin/git config --local --unset-all extensions.worktreeConfig
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:49.1097348Z ##[group]Checking out the ref
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:49.1101487Z [command]/usr/bin/git checkout --progress --force -B main refs/remotes/origin/main
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:49.1235148Z Switched to a new branch 'main'
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:49.1237837Z branch 'main' set up to track 'origin/main'.
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:49.1244701Z ##[endgroup]
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:49.1278345Z [command]/usr/bin/git log -1 --format=%H
+Detect Changes	Run actions/checkout@v4	2026-01-08T18:48:49.1300254Z c79c77d68a90cadbd439c9613a7050501095c92d
+Detect Changes	Setup Node.js	﻿2026-01-08T18:48:49.1524590Z ##[group]Run actions/setup-node@v4
+Detect Changes	Setup Node.js	2026-01-08T18:48:49.1525131Z with:
+Detect Changes	Setup Node.js	2026-01-08T18:48:49.1525481Z   node-version: 22
+Detect Changes	Setup Node.js	2026-01-08T18:48:49.1525856Z   always-auth: false
+Detect Changes	Setup Node.js	2026-01-08T18:48:49.1526254Z   check-latest: false
+Detect Changes	Setup Node.js	2026-01-08T18:48:49.1526779Z   token: ***
+Detect Changes	Setup Node.js	2026-01-08T18:48:49.1527144Z env:
+Detect Changes	Setup Node.js	2026-01-08T18:48:49.1527487Z   CARGO_TERM_COLOR: always
+Detect Changes	Setup Node.js	2026-01-08T18:48:49.1527915Z   RUSTFLAGS: -Dwarnings
+Detect Changes	Setup Node.js	2026-01-08T18:48:49.1528308Z ##[endgroup]
+Detect Changes	Setup Node.js	2026-01-08T18:48:49.3279407Z Found in cache @ /opt/hostedtoolcache/node/22.21.1/x64
+Detect Changes	Setup Node.js	2026-01-08T18:48:49.3286989Z ##[group]Environment details
+Detect Changes	Setup Node.js	2026-01-08T18:48:51.8350557Z node: v22.21.1
+Detect Changes	Setup Node.js	2026-01-08T18:48:51.8351319Z npm: 10.9.4
+Detect Changes	Setup Node.js	2026-01-08T18:48:51.8353495Z yarn: 1.22.22
+Detect Changes	Setup Node.js	2026-01-08T18:48:51.8354713Z ##[endgroup]
+Detect Changes	Detect changes	﻿2026-01-08T18:48:51.8475415Z ##[group]Run node scripts/detect-code-changes.mjs
+Detect Changes	Detect changes	2026-01-08T18:48:51.8475937Z [36;1mnode scripts/detect-code-changes.mjs[0m
+Detect Changes	Detect changes	2026-01-08T18:48:51.8521323Z shell: /usr/bin/bash -e {0}
+Detect Changes	Detect changes	2026-01-08T18:48:51.8521652Z env:
+Detect Changes	Detect changes	2026-01-08T18:48:51.8521860Z   CARGO_TERM_COLOR: always
+Detect Changes	Detect changes	2026-01-08T18:48:51.8522115Z   RUSTFLAGS: -Dwarnings
+Detect Changes	Detect changes	2026-01-08T18:48:51.8522354Z   GITHUB_EVENT_NAME: push
+Detect Changes	Detect changes	2026-01-08T18:48:51.8522859Z   GITHUB_BASE_SHA: 
+Detect Changes	Detect changes	2026-01-08T18:48:51.8523081Z   GITHUB_HEAD_SHA: 
+Detect Changes	Detect changes	2026-01-08T18:48:51.8523333Z ##[endgroup]
+Detect Changes	Detect changes	2026-01-08T18:48:51.8850527Z Detecting file changes for CI/CD...
+Detect Changes	Detect changes	2026-01-08T18:48:51.8850861Z 
+Detect Changes	Detect changes	2026-01-08T18:48:51.8851088Z Comparing HEAD^ to HEAD
+Detect Changes	Detect changes	2026-01-08T18:48:51.8897635Z Changed files:
+Detect Changes	Detect changes	2026-01-08T18:48:51.8898169Z   .github/workflows/js.yml
+Detect Changes	Detect changes	2026-01-08T18:48:51.8898675Z   .github/workflows/rust.yml
+Detect Changes	Detect changes	2026-01-08T18:48:51.8899547Z   js/.changeset/ci-cd-improvements.md
+Detect Changes	Detect changes	2026-01-08T18:48:51.8900216Z   js/scripts/check-changesets.mjs
+Detect Changes	Detect changes	2026-01-08T18:48:51.8900807Z   js/scripts/check-version.mjs
+Detect Changes	Detect changes	2026-01-08T18:48:51.8901495Z   js/scripts/detect-code-changes.mjs
+Detect Changes	Detect changes	2026-01-08T18:48:51.8903721Z   js/scripts/merge-changesets.mjs
+Detect Changes	Detect changes	2026-01-08T18:48:51.8904521Z   rust/changelog.d/20260108_193000_ci_cd_improvements.md
+Detect Changes	Detect changes	2026-01-08T18:48:51.8905251Z   rust/scripts/check-changelog-fragment.mjs
+Detect Changes	Detect changes	2026-01-08T18:48:51.8905905Z   rust/scripts/check-file-size.mjs
+Detect Changes	Detect changes	2026-01-08T18:48:51.8906436Z   rust/scripts/check-version-modification.mjs
+Detect Changes	Detect changes	2026-01-08T18:48:51.8906873Z   rust/scripts/detect-code-changes.mjs
+Detect Changes	Detect changes	2026-01-08T18:48:51.8907753Z   rust/scripts/git-config.mjs
+Detect Changes	Detect changes	2026-01-08T18:48:51.8908069Z 
+Detect Changes	Detect changes	2026-01-08T18:48:51.8908271Z rs-changed=false
+Detect Changes	Detect changes	2026-01-08T18:48:51.8908743Z toml-changed=false
+Detect Changes	Detect changes	2026-01-08T18:48:51.8909190Z mjs-changed=true
+Detect Changes	Detect changes	2026-01-08T18:48:51.8909621Z docs-changed=true
+Detect Changes	Detect changes	2026-01-08T18:48:51.8910566Z workflow-changed=true
+Detect Changes	Detect changes	2026-01-08T18:48:51.8911437Z 
+Detect Changes	Detect changes	2026-01-08T18:48:51.8911791Z Files considered as code changes:
+Detect Changes	Detect changes	2026-01-08T18:48:51.8912329Z   .github/workflows/js.yml
+Detect Changes	Detect changes	2026-01-08T18:48:51.8912980Z   .github/workflows/rust.yml
+Detect Changes	Detect changes	2026-01-08T18:48:51.8913544Z   js/scripts/check-changesets.mjs
+Detect Changes	Detect changes	2026-01-08T18:48:51.8914077Z   js/scripts/check-version.mjs
+Detect Changes	Detect changes	2026-01-08T18:48:51.8914628Z   js/scripts/detect-code-changes.mjs
+Detect Changes	Detect changes	2026-01-08T18:48:51.8914979Z   js/scripts/merge-changesets.mjs
+Detect Changes	Detect changes	2026-01-08T18:48:51.8915334Z   rust/scripts/check-changelog-fragment.mjs
+Detect Changes	Detect changes	2026-01-08T18:48:51.8915728Z   rust/scripts/check-file-size.mjs
+Detect Changes	Detect changes	2026-01-08T18:48:51.8916271Z   rust/scripts/check-version-modification.mjs
+Detect Changes	Detect changes	2026-01-08T18:48:51.8916931Z   rust/scripts/detect-code-changes.mjs
+Detect Changes	Detect changes	2026-01-08T18:48:51.8917332Z   rust/scripts/git-config.mjs
+Detect Changes	Detect changes	2026-01-08T18:48:51.8917516Z 
+Detect Changes	Detect changes	2026-01-08T18:48:51.8917670Z any-code-changed=true
+Detect Changes	Detect changes	2026-01-08T18:48:51.8917836Z 
+Detect Changes	Detect changes	2026-01-08T18:48:51.8917975Z Change detection completed.
+Detect Changes	Post Setup Node.js	﻿2026-01-08T18:48:51.9104876Z Post job cleanup.
+Detect Changes	Post Run actions/checkout@v4	﻿2026-01-08T18:48:52.0750866Z Post job cleanup.
+Detect Changes	Post Run actions/checkout@v4	2026-01-08T18:48:52.1700541Z [command]/usr/bin/git version
+Detect Changes	Post Run actions/checkout@v4	2026-01-08T18:48:52.1736583Z git version 2.52.0
+Detect Changes	Post Run actions/checkout@v4	2026-01-08T18:48:52.1779791Z Temporarily overriding HOME='/home/runner/work/_temp/7619074a-d510-473b-bc8e-0a7979e27f49' before making global git config changes
+Detect Changes	Post Run actions/checkout@v4	2026-01-08T18:48:52.1781401Z Adding repository directory to the temporary git global config as a safe directory
+Detect Changes	Post Run actions/checkout@v4	2026-01-08T18:48:52.1791002Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/lino-objects-codec/lino-objects-codec
+Detect Changes	Post Run actions/checkout@v4	2026-01-08T18:48:52.1823966Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+Detect Changes	Post Run actions/checkout@v4	2026-01-08T18:48:52.1855301Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+Detect Changes	Post Run actions/checkout@v4	2026-01-08T18:48:52.2079827Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Detect Changes	Post Run actions/checkout@v4	2026-01-08T18:48:52.2100221Z http.https://github.com/.extraheader
+Detect Changes	Post Run actions/checkout@v4	2026-01-08T18:48:52.2113492Z [command]/usr/bin/git config --local --unset-all http.https://github.com/.extraheader
+Detect Changes	Post Run actions/checkout@v4	2026-01-08T18:48:52.2144378Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+Detect Changes	Post Run actions/checkout@v4	2026-01-08T18:48:52.2364198Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+Detect Changes	Post Run actions/checkout@v4	2026-01-08T18:48:52.2395463Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+Detect Changes	Complete job	﻿2026-01-08T18:48:52.2714033Z Evaluate and set job outputs
+Detect Changes	Complete job	2026-01-08T18:48:52.2721481Z Set output 'rs-changed'
+Detect Changes	Complete job	2026-01-08T18:48:52.2723542Z Set output 'toml-changed'
+Detect Changes	Complete job	2026-01-08T18:48:52.2724238Z Set output 'mjs-changed'
+Detect Changes	Complete job	2026-01-08T18:48:52.2724599Z Set output 'docs-changed'
+Detect Changes	Complete job	2026-01-08T18:48:52.2724951Z Set output 'workflow-changed'
+Detect Changes	Complete job	2026-01-08T18:48:52.2725291Z Set output 'any-code-changed'
+Detect Changes	Complete job	2026-01-08T18:48:52.2725991Z Cleaning up orphan processes
+Lint and Format Check	Set up job	﻿2026-01-08T18:48:56.6170681Z Current runner version: '2.330.0'
+Lint and Format Check	Set up job	2026-01-08T18:48:56.6195236Z ##[group]Runner Image Provisioner
+Lint and Format Check	Set up job	2026-01-08T18:48:56.6196541Z Hosted Compute Agent
+Lint and Format Check	Set up job	2026-01-08T18:48:56.6197087Z Version: 20251211.462
+Lint and Format Check	Set up job	2026-01-08T18:48:56.6197700Z Commit: 6cbad8c2bb55d58165063d031ccabf57e2d2db61
+Lint and Format Check	Set up job	2026-01-08T18:48:56.6198448Z Build Date: 2025-12-11T16:28:49Z
+Lint and Format Check	Set up job	2026-01-08T18:48:56.6199085Z Worker ID: {4940474e-731f-421f-987a-bd50ee8bf814}
+Lint and Format Check	Set up job	2026-01-08T18:48:56.6199730Z ##[endgroup]
+Lint and Format Check	Set up job	2026-01-08T18:48:56.6200311Z ##[group]Operating System
+Lint and Format Check	Set up job	2026-01-08T18:48:56.6200832Z Ubuntu
+Lint and Format Check	Set up job	2026-01-08T18:48:56.6201304Z 24.04.3
+Lint and Format Check	Set up job	2026-01-08T18:48:56.6201797Z LTS
+Lint and Format Check	Set up job	2026-01-08T18:48:56.6202206Z ##[endgroup]
+Lint and Format Check	Set up job	2026-01-08T18:48:56.6202715Z ##[group]Runner Image
+Lint and Format Check	Set up job	2026-01-08T18:48:56.6203240Z Image: ubuntu-24.04
+Lint and Format Check	Set up job	2026-01-08T18:48:56.6203754Z Version: 20251215.174.1
+Lint and Format Check	Set up job	2026-01-08T18:48:56.6204698Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20251215.174/images/ubuntu/Ubuntu2404-Readme.md
+Lint and Format Check	Set up job	2026-01-08T18:48:56.6206671Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20251215.174
+Lint and Format Check	Set up job	2026-01-08T18:48:56.6207917Z ##[endgroup]
+Lint and Format Check	Set up job	2026-01-08T18:48:56.6210544Z ##[group]GITHUB_TOKEN Permissions
+Lint and Format Check	Set up job	2026-01-08T18:48:56.6212782Z Actions: write
+Lint and Format Check	Set up job	2026-01-08T18:48:56.6213421Z ArtifactMetadata: write
+Lint and Format Check	Set up job	2026-01-08T18:48:56.6213950Z Attestations: write
+Lint and Format Check	Set up job	2026-01-08T18:48:56.6214453Z Checks: write
+Lint and Format Check	Set up job	2026-01-08T18:48:56.6214887Z Contents: write
+Lint and Format Check	Set up job	2026-01-08T18:48:56.6215453Z Deployments: write
+Lint and Format Check	Set up job	2026-01-08T18:48:56.6216192Z Discussions: write
+Lint and Format Check	Set up job	2026-01-08T18:48:56.6216698Z Issues: write
+Lint and Format Check	Set up job	2026-01-08T18:48:56.6217259Z Metadata: read
+Lint and Format Check	Set up job	2026-01-08T18:48:56.6217708Z Models: read
+Lint and Format Check	Set up job	2026-01-08T18:48:56.6218171Z Packages: write
+Lint and Format Check	Set up job	2026-01-08T18:48:56.6218696Z Pages: write
+Lint and Format Check	Set up job	2026-01-08T18:48:56.6219224Z PullRequests: write
+Lint and Format Check	Set up job	2026-01-08T18:48:56.6219810Z RepositoryProjects: write
+Lint and Format Check	Set up job	2026-01-08T18:48:56.6220737Z SecurityEvents: write
+Lint and Format Check	Set up job	2026-01-08T18:48:56.6221262Z Statuses: write
+Lint and Format Check	Set up job	2026-01-08T18:48:56.6221716Z ##[endgroup]
+Lint and Format Check	Set up job	2026-01-08T18:48:56.6223810Z Secret source: Actions
+Lint and Format Check	Set up job	2026-01-08T18:48:56.6224782Z Prepare workflow directory
+Lint and Format Check	Set up job	2026-01-08T18:48:56.6613851Z Prepare all required actions
+Lint and Format Check	Set up job	2026-01-08T18:48:56.6670355Z Getting action download info
+Lint and Format Check	Set up job	2026-01-08T18:48:57.0841314Z Download action repository 'actions/checkout@v4' (SHA:34e114876b0b11c390a56381ad16ebd13914f8d5)
+Lint and Format Check	Set up job	2026-01-08T18:48:57.2001783Z Download action repository 'dtolnay/rust-toolchain@stable' (SHA:4be9e76fd7c4901c61fb841f559994984270fce7)
+Lint and Format Check	Set up job	2026-01-08T18:48:57.5202415Z Download action repository 'actions/setup-node@v4' (SHA:49933ea5288caeca8642d1e84afbd3f7d6820020)
+Lint and Format Check	Set up job	2026-01-08T18:48:57.6100206Z Download action repository 'actions/cache@v4' (SHA:0057852bfaa89a56745cba8c7296529d2fc39830)
+Lint and Format Check	Set up job	2026-01-08T18:48:57.8508414Z Complete job name: Lint and Format Check
+Lint and Format Check	Run actions/checkout@v4	﻿2026-01-08T18:48:57.9227988Z ##[group]Run actions/checkout@v4
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:57.9228902Z with:
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:57.9229399Z   repository: link-foundation/lino-objects-codec
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:57.9230190Z   token: ***
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:57.9230593Z   ssh-strict: true
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:57.9231038Z   ssh-user: git
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:57.9231458Z   persist-credentials: true
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:57.9231939Z   clean: true
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:57.9232357Z   sparse-checkout-cone-mode: true
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:57.9232866Z   fetch-depth: 1
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:57.9233298Z   fetch-tags: false
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:57.9233715Z   show-progress: true
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:57.9234152Z   lfs: false
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:57.9234543Z   submodules: false
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:57.9234974Z   set-safe-directory: true
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:57.9235633Z env:
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:57.9236219Z   CARGO_TERM_COLOR: always
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:57.9236729Z   RUSTFLAGS: -Dwarnings
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:57.9237181Z ##[endgroup]
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:58.0322035Z Syncing repository: link-foundation/lino-objects-codec
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:58.0324447Z ##[group]Getting Git version info
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:58.0325343Z Working directory is '/home/runner/work/lino-objects-codec/lino-objects-codec'
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:58.0326941Z [command]/usr/bin/git version
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:58.0404856Z git version 2.52.0
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:58.0431307Z ##[endgroup]
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:58.0446018Z Temporarily overriding HOME='/home/runner/work/_temp/80dba4f8-149d-4819-81b5-13ff663efb74' before making global git config changes
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:58.0448287Z Adding repository directory to the temporary git global config as a safe directory
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:58.0451230Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/lino-objects-codec/lino-objects-codec
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:58.0489773Z Deleting the contents of '/home/runner/work/lino-objects-codec/lino-objects-codec'
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:58.0493171Z ##[group]Initializing the repository
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:58.0497342Z [command]/usr/bin/git init /home/runner/work/lino-objects-codec/lino-objects-codec
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:58.0603861Z hint: Using 'master' as the name for the initial branch. This default branch name
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:58.0605620Z hint: will change to "main" in Git 3.0. To configure the initial branch name
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:58.0607210Z hint: to use in all of your new repositories, which will suppress this warning,
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:58.0608449Z hint: call:
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:58.0609251Z hint:
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:58.0609914Z hint: 	git config --global init.defaultBranch <name>
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:58.0611127Z hint:
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:58.0612360Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:58.0614312Z hint: 'development'. The just-created branch can be renamed via this command:
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:58.0616040Z hint:
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:58.0616898Z hint: 	git branch -m <name>
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:58.0617789Z hint:
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:58.0618943Z hint: Disable this message with "git config set advice.defaultBranchName false"
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:58.0621177Z Initialized empty Git repository in /home/runner/work/lino-objects-codec/lino-objects-codec/.git/
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:58.0624851Z [command]/usr/bin/git remote add origin https://github.com/link-foundation/lino-objects-codec
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:58.0661978Z ##[endgroup]
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:58.0663374Z ##[group]Disabling automatic garbage collection
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:58.0667034Z [command]/usr/bin/git config --local gc.auto 0
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:58.0695089Z ##[endgroup]
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:58.0696052Z ##[group]Setting up auth
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:58.0702218Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:58.0731860Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:58.1088750Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:58.1120405Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:58.1344334Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:58.1385152Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:58.1611014Z [command]/usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:58.1646765Z ##[endgroup]
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:58.1648428Z ##[group]Fetching the repository
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:58.1656555Z [command]/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +c79c77d68a90cadbd439c9613a7050501095c92d:refs/remotes/origin/main
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:58.5154792Z From https://github.com/link-foundation/lino-objects-codec
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:58.5157813Z  * [new ref]         c79c77d68a90cadbd439c9613a7050501095c92d -> origin/main
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:58.5188799Z ##[endgroup]
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:58.5189988Z ##[group]Determining the checkout info
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:58.5191556Z ##[endgroup]
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:58.5197696Z [command]/usr/bin/git sparse-checkout disable
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:58.5241748Z [command]/usr/bin/git config --local --unset-all extensions.worktreeConfig
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:58.5270625Z ##[group]Checking out the ref
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:58.5274893Z [command]/usr/bin/git checkout --progress --force -B main refs/remotes/origin/main
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:58.5403176Z Switched to a new branch 'main'
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:58.5405185Z branch 'main' set up to track 'origin/main'.
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:58.5414178Z ##[endgroup]
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:58.5453434Z [command]/usr/bin/git log -1 --format=%H
+Lint and Format Check	Run actions/checkout@v4	2026-01-08T18:48:58.5477773Z c79c77d68a90cadbd439c9613a7050501095c92d
+Lint and Format Check	Set up Rust	﻿2026-01-08T18:48:58.6067231Z ##[group]Run dtolnay/rust-toolchain@stable
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.6068473Z with:
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.6069273Z   components: rustfmt, clippy
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.6070234Z   toolchain: stable
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.6071057Z env:
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.6071814Z   CARGO_TERM_COLOR: always
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.6072764Z   RUSTFLAGS: -Dwarnings
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.6073653Z ##[endgroup]
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.6289201Z ##[group]Run : parse toolchain version
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.6290458Z [36;1m: parse toolchain version[0m
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.6291510Z [36;1mif [[ -z $toolchain ]]; then[0m
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.6293388Z [36;1m  # GitHub does not enforce `required: true` inputs itself. https://github.com/actions/runner/issues/1070[0m
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.6295425Z [36;1m  echo "'toolchain' is a required input" >&2[0m
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.6296800Z [36;1m  exit 1[0m
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.6298043Z [36;1melif [[ $toolchain =~ ^stable' '[0-9]+' '(year|month|week|day)s?' 'ago$ ]]; then[0m
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.6299598Z [36;1m  if [[ Linux == macOS ]]; then[0m
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.6301568Z [36;1m    echo "toolchain=1.$((($(date -v-$(sed 's/stable \([0-9]*\) \(.\).*/\1\2/' <<< $toolchain) +%s)/60/60/24-16569)/7/6))" >> $GITHUB_OUTPUT[0m
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.6303485Z [36;1m  else[0m
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.6304957Z [36;1m    echo "toolchain=1.$((($(date --date "${toolchain#stable }" +%s)/60/60/24-16569)/7/6))" >> $GITHUB_OUTPUT[0m
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.6306957Z [36;1m  fi[0m
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.6308084Z [36;1melif [[ $toolchain =~ ^stable' 'minus' '[0-9]+' 'releases?$ ]]; then[0m
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.6310102Z [36;1m  echo "toolchain=1.$((($(date +%s)/60/60/24-16569)/7/6-${toolchain//[^0-9]/}))" >> $GITHUB_OUTPUT[0m
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.6311878Z [36;1melif [[ $toolchain =~ ^1\.[0-9]+$ ]]; then[0m
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.6313872Z [36;1m  echo "toolchain=1.$((i=${toolchain#1.}, c=($(date +%s)/60/60/24-16569)/7/6, i+9*i*(10*i<=c)+90*i*(100*i<=c)))" >> $GITHUB_OUTPUT[0m
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.6315762Z [36;1melse[0m
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.6316923Z [36;1m  echo "toolchain=$toolchain" >> $GITHUB_OUTPUT[0m
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.6318108Z [36;1mfi[0m
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.6358115Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.6359392Z env:
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.6360099Z   CARGO_TERM_COLOR: always
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.6360989Z   RUSTFLAGS: -Dwarnings
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.6361817Z   toolchain: stable
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.6362581Z ##[endgroup]
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.6548063Z ##[group]Run : construct rustup command line
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.6549306Z [36;1m: construct rustup command line[0m
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.6550943Z [36;1mecho "targets=$(for t in ${targets//,/ }; do echo -n ' --target' $t; done)" >> $GITHUB_OUTPUT[0m
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.6553234Z [36;1mecho "components=$(for c in ${components//,/ }; do echo -n ' --component' $c; done)" >> $GITHUB_OUTPUT[0m
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.6555012Z [36;1mecho "downgrade=" >> $GITHUB_OUTPUT[0m
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.6590217Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.6591436Z env:
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.6592124Z   CARGO_TERM_COLOR: always
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.6592985Z   RUSTFLAGS: -Dwarnings
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.6593794Z   targets: 
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.6594518Z   components: rustfmt, clippy
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.6595385Z ##[endgroup]
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.6745776Z ##[group]Run : set $CARGO_HOME
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.6747585Z [36;1m: set $CARGO_HOME[0m
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.6749926Z [36;1mecho CARGO_HOME=${CARGO_HOME:-"$HOME/.cargo"} >> $GITHUB_ENV[0m
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.6801779Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.6803014Z env:
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.6803720Z   CARGO_TERM_COLOR: always
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.6804593Z   RUSTFLAGS: -Dwarnings
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.6805397Z ##[endgroup]
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.6933076Z ##[group]Run : install rustup if needed
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.6934152Z [36;1m: install rustup if needed[0m
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.6935239Z [36;1mif ! command -v rustup &>/dev/null; then[0m
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.6938095Z [36;1m  curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused --location --silent --show-error --fail https://sh.rustup.rs | sh -s -- --default-toolchain none -y[0m
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.6940966Z [36;1m  echo "$CARGO_HOME/bin" >> $GITHUB_PATH[0m
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.6942018Z [36;1mfi[0m
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.6977721Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.6978933Z env:
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.6979649Z   CARGO_TERM_COLOR: always
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.6980522Z   RUSTFLAGS: -Dwarnings
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.6981371Z   CARGO_HOME: /home/runner/.cargo
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.6982298Z ##[endgroup]
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.7105023Z ##[group]Run rustup toolchain install stable --component rustfmt --component clippy --profile minimal --no-self-update
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.7108092Z [36;1mrustup toolchain install stable --component rustfmt --component clippy --profile minimal --no-self-update[0m
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.7145206Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.7146614Z env:
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.7147317Z   CARGO_TERM_COLOR: always
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.7148202Z   RUSTFLAGS: -Dwarnings
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.7149063Z   CARGO_HOME: /home/runner/.cargo
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.7150022Z   RUSTUP_PERMIT_COPY_RENAME: 1
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.7150990Z ##[endgroup]
+Lint and Format Check	Set up Rust	2026-01-08T18:48:58.9259632Z info: syncing channel updates for 'stable-x86_64-unknown-linux-gnu'
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.1697438Z info: latest update on 2025-12-11, rust version 1.92.0 (ded5c06cf 2025-12-08)
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.2018242Z info: component 'clippy' for target 'x86_64-unknown-linux-gnu' is up to date
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.2021395Z info: component 'rustfmt' for target 'x86_64-unknown-linux-gnu' is up to date
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.2044722Z 
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.2134464Z   stable-x86_64-unknown-linux-gnu unchanged - rustc 1.92.0 (ded5c06cf 2025-12-08)
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.2136255Z 
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.2205597Z ##[group]Run rustup default stable
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.2206822Z [36;1mrustup default stable[0m
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.2244974Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.2246335Z env:
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.2247041Z   CARGO_TERM_COLOR: always
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.2247901Z   RUSTFLAGS: -Dwarnings
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.2248737Z   CARGO_HOME: /home/runner/.cargo
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.2249636Z ##[endgroup]
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.2365399Z info: using existing install for 'stable-x86_64-unknown-linux-gnu'
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.2735134Z info: default toolchain set to 'stable-x86_64-unknown-linux-gnu'
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.2736981Z 
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.2825320Z   stable-x86_64-unknown-linux-gnu unchanged - rustc 1.92.0 (ded5c06cf 2025-12-08)
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.2826956Z 
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.2958282Z ##[group]Run : create cachekey
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.2959250Z [36;1m: create cachekey[0m
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.2961016Z [36;1mDATE=$(rustc +stable --version --verbose | sed -ne 's/^commit-date: \(20[0-9][0-9]\)-\([01][0-9]\)-\([0-3][0-9]\)$/\1\2\3/p')[0m
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.2963323Z [36;1mHASH=$(rustc +stable --version --verbose | sed -ne 's/^commit-hash: //p')[0m
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.2965105Z [36;1mecho "cachekey=$(echo $DATE$HASH | head -c12)" >> $GITHUB_OUTPUT[0m
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.3003460Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.3004646Z env:
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.3005333Z   CARGO_TERM_COLOR: always
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.3006311Z   RUSTFLAGS: -Dwarnings
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.3007156Z   CARGO_HOME: /home/runner/.cargo
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.3008344Z ##[endgroup]
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.3464932Z ##[group]Run : disable incremental compilation
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.3466364Z [36;1m: disable incremental compilation[0m
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.3467533Z [36;1mif [ -z "${CARGO_INCREMENTAL+set}" ]; then[0m
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.3468735Z [36;1m  echo CARGO_INCREMENTAL=0 >> $GITHUB_ENV[0m
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.3469783Z [36;1mfi[0m
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.3507356Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.3508517Z env:
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.3509205Z   CARGO_TERM_COLOR: always
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.3510276Z   RUSTFLAGS: -Dwarnings
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.3511124Z   CARGO_HOME: /home/runner/.cargo
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.3512034Z ##[endgroup]
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.3618307Z ##[group]Run : enable colors in Cargo output
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.3619429Z [36;1m: enable colors in Cargo output[0m
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.3620537Z [36;1mif [ -z "${CARGO_TERM_COLOR+set}" ]; then[0m
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.3621791Z [36;1m  echo CARGO_TERM_COLOR=always >> $GITHUB_ENV[0m
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.3622873Z [36;1mfi[0m
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.3657916Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.3659101Z env:
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.3659785Z   CARGO_TERM_COLOR: always
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.3660654Z   RUSTFLAGS: -Dwarnings
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.3661498Z   CARGO_HOME: /home/runner/.cargo
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.3662427Z   CARGO_INCREMENTAL: 0
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.3663213Z ##[endgroup]
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.3774411Z ##[group]Run : enable Cargo sparse registry
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.3775522Z [36;1m: enable Cargo sparse registry[0m
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.3777108Z [36;1m# implemented in 1.66, stabilized in 1.68, made default in 1.70[0m
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.3779532Z [36;1mif [ -z "${CARGO_REGISTRIES_CRATES_IO_PROTOCOL+set}" -o -f "/home/runner/work/_temp"/.implicit_cargo_registries_crates_io_protocol ]; then[0m
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.3782095Z [36;1m  if rustc +stable --version --verbose | grep -q '^release: 1\.6[89]\.'; then[0m
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.3784148Z [36;1m    touch "/home/runner/work/_temp"/.implicit_cargo_registries_crates_io_protocol || true[0m
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.3786267Z [36;1m    echo CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse >> $GITHUB_ENV[0m
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.3788072Z [36;1m  elif rustc +stable --version --verbose | grep -q '^release: 1\.6[67]\.'; then[0m
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.3790099Z [36;1m    touch "/home/runner/work/_temp"/.implicit_cargo_registries_crates_io_protocol || true[0m
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.3791979Z [36;1m    echo CARGO_REGISTRIES_CRATES_IO_PROTOCOL=git >> $GITHUB_ENV[0m
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.3793255Z [36;1m  fi[0m
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.3793971Z [36;1mfi[0m
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.3829797Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.3830968Z env:
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.3831670Z   CARGO_TERM_COLOR: always
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.3832527Z   RUSTFLAGS: -Dwarnings
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.3833367Z   CARGO_HOME: /home/runner/.cargo
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.3834279Z   CARGO_INCREMENTAL: 0
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.3835054Z ##[endgroup]
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.4245468Z ##[group]Run : work around spurious network errors in curl 8.0
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.4247202Z [36;1m: work around spurious network errors in curl 8.0[0m
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.4249043Z [36;1m# https://rust-lang.zulipchat.com/#narrow/stream/246057-t-cargo/topic/timeout.20investigation[0m
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.4251134Z [36;1mif rustc +stable --version --verbose | grep -q '^release: 1\.7[01]\.'; then[0m
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.4252725Z [36;1m  echo CARGO_HTTP_MULTIPLEXING=false >> $GITHUB_ENV[0m
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.4253833Z [36;1mfi[0m
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.4291883Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.4293051Z env:
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.4316469Z   CARGO_TERM_COLOR: always
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.4317440Z   RUSTFLAGS: -Dwarnings
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.4318295Z   CARGO_HOME: /home/runner/.cargo
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.4319235Z   CARGO_INCREMENTAL: 0
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.4320007Z ##[endgroup]
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.4586232Z ##[group]Run rustc +stable --version --verbose
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.4587442Z [36;1mrustc +stable --version --verbose[0m
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.4625686Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.4627092Z env:
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.4627791Z   CARGO_TERM_COLOR: always
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.4628652Z   RUSTFLAGS: -Dwarnings
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.4629496Z   CARGO_HOME: /home/runner/.cargo
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.4630431Z   CARGO_INCREMENTAL: 0
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.4631207Z ##[endgroup]
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.4825005Z rustc 1.92.0 (ded5c06cf 2025-12-08)
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.4827777Z binary: rustc
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.4829277Z commit-hash: ded5c06cf21d2b93bffd5d884aa6e96934ee4234
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.4831143Z commit-date: 2025-12-08
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.4832200Z host: x86_64-unknown-linux-gnu
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.4833091Z release: 1.92.0
+Lint and Format Check	Set up Rust	2026-01-08T18:48:59.4833861Z LLVM version: 21.1.3
+Lint and Format Check	Setup Node.js	﻿2026-01-08T18:48:59.5019816Z ##[group]Run actions/setup-node@v4
+Lint and Format Check	Setup Node.js	2026-01-08T18:48:59.5020767Z with:
+Lint and Format Check	Setup Node.js	2026-01-08T18:48:59.5021472Z   node-version: 22
+Lint and Format Check	Setup Node.js	2026-01-08T18:48:59.5022209Z   always-auth: false
+Lint and Format Check	Setup Node.js	2026-01-08T18:48:59.5023006Z   check-latest: false
+Lint and Format Check	Setup Node.js	2026-01-08T18:48:59.5024061Z   token: ***
+Lint and Format Check	Setup Node.js	2026-01-08T18:48:59.5024750Z env:
+Lint and Format Check	Setup Node.js	2026-01-08T18:48:59.5025449Z   CARGO_TERM_COLOR: always
+Lint and Format Check	Setup Node.js	2026-01-08T18:48:59.5026440Z   RUSTFLAGS: -Dwarnings
+Lint and Format Check	Setup Node.js	2026-01-08T18:48:59.5027289Z   CARGO_HOME: /home/runner/.cargo
+Lint and Format Check	Setup Node.js	2026-01-08T18:48:59.5028200Z   CARGO_INCREMENTAL: 0
+Lint and Format Check	Setup Node.js	2026-01-08T18:48:59.5028975Z ##[endgroup]
+Lint and Format Check	Setup Node.js	2026-01-08T18:48:59.7071117Z Found in cache @ /opt/hostedtoolcache/node/22.21.1/x64
+Lint and Format Check	Setup Node.js	2026-01-08T18:48:59.7076727Z ##[group]Environment details
+Lint and Format Check	Setup Node.js	2026-01-08T18:49:00.0978704Z node: v22.21.1
+Lint and Format Check	Setup Node.js	2026-01-08T18:49:00.0979760Z npm: 10.9.4
+Lint and Format Check	Setup Node.js	2026-01-08T18:49:00.0980738Z yarn: 1.22.22
+Lint and Format Check	Setup Node.js	2026-01-08T18:49:00.0982501Z ##[endgroup]
+Lint and Format Check	Cache cargo dependencies	﻿2026-01-08T18:49:00.1708550Z ##[group]Run actions/cache@v4
+Lint and Format Check	Cache cargo dependencies	2026-01-08T18:49:00.1709455Z with:
+Lint and Format Check	Cache cargo dependencies	2026-01-08T18:49:00.1710721Z   path: ~/.cargo/bin/
+Lint and Format Check	Cache cargo dependencies	~/.cargo/registry/index/
+Lint and Format Check	Cache cargo dependencies	~/.cargo/registry/cache/
+Lint and Format Check	Cache cargo dependencies	~/.cargo/git/db/
+Lint and Format Check	Cache cargo dependencies	rust/target/
+Lint and Format Check	Cache cargo dependencies	
+Lint and Format Check	Cache cargo dependencies	2026-01-08T18:49:00.1712851Z   key: Linux-cargo-3bdf1052f98aec50857f27e3615100242b9f9c1f98c417d8384cf7fd70b81aba
+Lint and Format Check	Cache cargo dependencies	2026-01-08T18:49:00.1714383Z   enableCrossOsArchive: false
+Lint and Format Check	Cache cargo dependencies	2026-01-08T18:49:00.1715274Z   fail-on-cache-miss: false
+Lint and Format Check	Cache cargo dependencies	2026-01-08T18:49:00.1716285Z   lookup-only: false
+Lint and Format Check	Cache cargo dependencies	2026-01-08T18:49:00.1717048Z   save-always: false
+Lint and Format Check	Cache cargo dependencies	2026-01-08T18:49:00.1717775Z env:
+Lint and Format Check	Cache cargo dependencies	2026-01-08T18:49:00.1718435Z   CARGO_TERM_COLOR: always
+Lint and Format Check	Cache cargo dependencies	2026-01-08T18:49:00.1719267Z   RUSTFLAGS: -Dwarnings
+Lint and Format Check	Cache cargo dependencies	2026-01-08T18:49:00.1720072Z   CARGO_HOME: /home/runner/.cargo
+Lint and Format Check	Cache cargo dependencies	2026-01-08T18:49:00.1720970Z   CARGO_INCREMENTAL: 0
+Lint and Format Check	Cache cargo dependencies	2026-01-08T18:49:00.1721726Z ##[endgroup]
+Lint and Format Check	Cache cargo dependencies	2026-01-08T18:49:00.4591448Z Cache hit for: Linux-cargo-3bdf1052f98aec50857f27e3615100242b9f9c1f98c417d8384cf7fd70b81aba
+Lint and Format Check	Cache cargo dependencies	2026-01-08T18:49:01.1673175Z Received 8743147 of 8743147 (100.0%), 15.3 MBs/sec
+Lint and Format Check	Cache cargo dependencies	2026-01-08T18:49:01.1674343Z Cache Size: ~8 MB (8743147 B)
+Lint and Format Check	Cache cargo dependencies	2026-01-08T18:49:01.1703997Z [command]/usr/bin/tar -xf /home/runner/work/_temp/243a40c1-06fc-4184-be35-e78f4e71620c/cache.tzst -P -C /home/runner/work/lino-objects-codec/lino-objects-codec --use-compress-program unzstd
+Lint and Format Check	Cache cargo dependencies	2026-01-08T18:49:01.2220171Z Cache restored successfully
+Lint and Format Check	Cache cargo dependencies	2026-01-08T18:49:01.2319576Z Cache restored from key: Linux-cargo-3bdf1052f98aec50857f27e3615100242b9f9c1f98c417d8384cf7fd70b81aba
+Lint and Format Check	Check formatting	﻿2026-01-08T18:49:01.2423256Z ##[group]Run cargo fmt --check
+Lint and Format Check	Check formatting	2026-01-08T18:49:01.2423609Z [36;1mcargo fmt --check[0m
+Lint and Format Check	Check formatting	2026-01-08T18:49:01.2465218Z shell: /usr/bin/bash -e {0}
+Lint and Format Check	Check formatting	2026-01-08T18:49:01.2465483Z env:
+Lint and Format Check	Check formatting	2026-01-08T18:49:01.2465671Z   CARGO_TERM_COLOR: always
+Lint and Format Check	Check formatting	2026-01-08T18:49:01.2466056Z   RUSTFLAGS: -Dwarnings
+Lint and Format Check	Check formatting	2026-01-08T18:49:01.2466294Z   CARGO_HOME: /home/runner/.cargo
+Lint and Format Check	Check formatting	2026-01-08T18:49:01.2466537Z   CARGO_INCREMENTAL: 0
+Lint and Format Check	Check formatting	2026-01-08T18:49:01.2466744Z ##[endgroup]
+Lint and Format Check	Run clippy	﻿2026-01-08T18:49:02.1697642Z ##[group]Run cargo clippy --all-targets --all-features
+Lint and Format Check	Run clippy	2026-01-08T18:49:02.1698139Z [36;1mcargo clippy --all-targets --all-features[0m
+Lint and Format Check	Run clippy	2026-01-08T18:49:02.1730159Z shell: /usr/bin/bash -e {0}
+Lint and Format Check	Run clippy	2026-01-08T18:49:02.1730423Z env:
+Lint and Format Check	Run clippy	2026-01-08T18:49:02.1730778Z   CARGO_TERM_COLOR: always
+Lint and Format Check	Run clippy	2026-01-08T18:49:02.1731005Z   RUSTFLAGS: -Dwarnings
+Lint and Format Check	Run clippy	2026-01-08T18:49:02.1731226Z   CARGO_HOME: /home/runner/.cargo
+Lint and Format Check	Run clippy	2026-01-08T18:49:02.1731461Z   CARGO_INCREMENTAL: 0
+Lint and Format Check	Run clippy	2026-01-08T18:49:02.1731681Z ##[endgroup]
+Lint and Format Check	Run clippy	2026-01-08T18:49:02.8549180Z [1m[92m    Checking[0m memchr v2.7.6
+Lint and Format Check	Run clippy	2026-01-08T18:49:02.8550050Z [1m[92m    Checking[0m base64 v0.22.1
+Lint and Format Check	Run clippy	2026-01-08T18:49:03.2271251Z [1m[92m    Checking[0m nom v8.0.0
+Lint and Format Check	Run clippy	2026-01-08T18:49:04.8549434Z [1m[92m    Checking[0m links-notation v0.13.0
+Lint and Format Check	Run clippy	2026-01-08T18:49:05.0045726Z [1m[92m    Checking[0m lino-objects-codec v0.2.0 (/home/runner/work/lino-objects-codec/lino-objects-codec/rust)
+Lint and Format Check	Run clippy	2026-01-08T18:49:06.6112238Z [1m[92m    Finished[0m `dev` profile [unoptimized + debuginfo] target(s) in 4.11s
+Lint and Format Check	Check file size limit	﻿2026-01-08T18:49:06.6184492Z ##[group]Run node scripts/check-file-size.mjs
+Lint and Format Check	Check file size limit	2026-01-08T18:49:06.6184932Z [36;1mnode scripts/check-file-size.mjs[0m
+Lint and Format Check	Check file size limit	2026-01-08T18:49:06.6216760Z shell: /usr/bin/bash -e {0}
+Lint and Format Check	Check file size limit	2026-01-08T18:49:06.6217011Z env:
+Lint and Format Check	Check file size limit	2026-01-08T18:49:06.6217207Z   CARGO_TERM_COLOR: always
+Lint and Format Check	Check file size limit	2026-01-08T18:49:06.6217441Z   RUSTFLAGS: -Dwarnings
+Lint and Format Check	Check file size limit	2026-01-08T18:49:06.6217671Z   CARGO_HOME: /home/runner/.cargo
+Lint and Format Check	Check file size limit	2026-01-08T18:49:06.6217908Z   CARGO_INCREMENTAL: 0
+Lint and Format Check	Check file size limit	2026-01-08T18:49:06.6218110Z ##[endgroup]
+Lint and Format Check	Check file size limit	2026-01-08T18:49:06.6592633Z 
+Lint and Format Check	Check file size limit	2026-01-08T18:49:06.6593452Z Checking Rust files for maximum 2000 lines...
+Lint and Format Check	Check file size limit	2026-01-08T18:49:06.6594144Z 
+Lint and Format Check	Check file size limit	2026-01-08T18:49:06.6606734Z All files are within the line limit
+Lint and Format Check	Check file size limit	2026-01-08T18:49:06.6607136Z 
+Lint and Format Check	Post Cache cargo dependencies	﻿2026-01-08T18:49:06.7231671Z Post job cleanup.
+Lint and Format Check	Post Cache cargo dependencies	2026-01-08T18:49:06.8543121Z Cache hit occurred on the primary key Linux-cargo-3bdf1052f98aec50857f27e3615100242b9f9c1f98c417d8384cf7fd70b81aba, not saving cache.
+Lint and Format Check	Post Setup Node.js	﻿2026-01-08T18:49:06.8650941Z Post job cleanup.
+Lint and Format Check	Post Run actions/checkout@v4	﻿2026-01-08T18:49:07.0341972Z Post job cleanup.
+Lint and Format Check	Post Run actions/checkout@v4	2026-01-08T18:49:07.1301398Z [command]/usr/bin/git version
+Lint and Format Check	Post Run actions/checkout@v4	2026-01-08T18:49:07.1338637Z git version 2.52.0
+Lint and Format Check	Post Run actions/checkout@v4	2026-01-08T18:49:07.1383598Z Temporarily overriding HOME='/home/runner/work/_temp/6794011c-7334-4da3-bec8-8f9fd6fec94f' before making global git config changes
+Lint and Format Check	Post Run actions/checkout@v4	2026-01-08T18:49:07.1384759Z Adding repository directory to the temporary git global config as a safe directory
+Lint and Format Check	Post Run actions/checkout@v4	2026-01-08T18:49:07.1396711Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/lino-objects-codec/lino-objects-codec
+Lint and Format Check	Post Run actions/checkout@v4	2026-01-08T18:49:07.1432161Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+Lint and Format Check	Post Run actions/checkout@v4	2026-01-08T18:49:07.1466714Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+Lint and Format Check	Post Run actions/checkout@v4	2026-01-08T18:49:07.1701533Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Lint and Format Check	Post Run actions/checkout@v4	2026-01-08T18:49:07.1725670Z http.https://github.com/.extraheader
+Lint and Format Check	Post Run actions/checkout@v4	2026-01-08T18:49:07.1739367Z [command]/usr/bin/git config --local --unset-all http.https://github.com/.extraheader
+Lint and Format Check	Post Run actions/checkout@v4	2026-01-08T18:49:07.1777160Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+Lint and Format Check	Post Run actions/checkout@v4	2026-01-08T18:49:07.2004078Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+Lint and Format Check	Post Run actions/checkout@v4	2026-01-08T18:49:07.2036923Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+Lint and Format Check	Complete job	﻿2026-01-08T18:49:07.2362979Z Cleaning up orphan processes
+Test (Rust on macos-latest)	Set up job	﻿2026-01-08T18:48:56.8783730Z Current runner version: '2.330.0'
+Test (Rust on macos-latest)	Set up job	2026-01-08T18:48:56.8799130Z ##[group]Runner Image Provisioner
+Test (Rust on macos-latest)	Set up job	2026-01-08T18:48:56.8799630Z Hosted Compute Agent
+Test (Rust on macos-latest)	Set up job	2026-01-08T18:48:56.8799970Z Version: 20251211.462
+Test (Rust on macos-latest)	Set up job	2026-01-08T18:48:56.8800340Z Commit: 6cbad8c2bb55d58165063d031ccabf57e2d2db61
+Test (Rust on macos-latest)	Set up job	2026-01-08T18:48:56.8800780Z Build Date: 2025-12-11T16:28:49Z
+Test (Rust on macos-latest)	Set up job	2026-01-08T18:48:56.8801190Z Worker ID: {b920c2c0-d6e4-4895-911e-7c859ea13476}
+Test (Rust on macos-latest)	Set up job	2026-01-08T18:48:56.8801610Z ##[endgroup]
+Test (Rust on macos-latest)	Set up job	2026-01-08T18:48:56.8801930Z ##[group]Operating System
+Test (Rust on macos-latest)	Set up job	2026-01-08T18:48:56.8802280Z macOS
+Test (Rust on macos-latest)	Set up job	2026-01-08T18:48:56.8802690Z 15.7.3
+Test (Rust on macos-latest)	Set up job	2026-01-08T18:48:56.8802970Z 24G419
+Test (Rust on macos-latest)	Set up job	2026-01-08T18:48:56.8803240Z ##[endgroup]
+Test (Rust on macos-latest)	Set up job	2026-01-08T18:48:56.8803530Z ##[group]Runner Image
+Test (Rust on macos-latest)	Set up job	2026-01-08T18:48:56.8803850Z Image: macos-15-arm64
+Test (Rust on macos-latest)	Set up job	2026-01-08T18:48:56.8804160Z Version: 20260105.0094.1
+Test (Rust on macos-latest)	Set up job	2026-01-08T18:48:56.8804830Z Included Software: https://github.com/actions/runner-images/blob/macos-15-arm64/20260105.0094/images/macos/macos-15-arm64-Readme.md
+Test (Rust on macos-latest)	Set up job	2026-01-08T18:48:56.8805770Z Image Release: https://github.com/actions/runner-images/releases/tag/macos-15-arm64%2F20260105.0094
+Test (Rust on macos-latest)	Set up job	2026-01-08T18:48:56.8806430Z ##[endgroup]
+Test (Rust on macos-latest)	Set up job	2026-01-08T18:48:56.8808120Z ##[group]GITHUB_TOKEN Permissions
+Test (Rust on macos-latest)	Set up job	2026-01-08T18:48:56.8809210Z Actions: write
+Test (Rust on macos-latest)	Set up job	2026-01-08T18:48:56.8809530Z ArtifactMetadata: write
+Test (Rust on macos-latest)	Set up job	2026-01-08T18:48:56.8809850Z Attestations: write
+Test (Rust on macos-latest)	Set up job	2026-01-08T18:48:56.8810160Z Checks: write
+Test (Rust on macos-latest)	Set up job	2026-01-08T18:48:56.8810440Z Contents: write
+Test (Rust on macos-latest)	Set up job	2026-01-08T18:48:56.8810730Z Deployments: write
+Test (Rust on macos-latest)	Set up job	2026-01-08T18:48:56.8811030Z Discussions: write
+Test (Rust on macos-latest)	Set up job	2026-01-08T18:48:56.8811340Z Issues: write
+Test (Rust on macos-latest)	Set up job	2026-01-08T18:48:56.8811630Z Metadata: read
+Test (Rust on macos-latest)	Set up job	2026-01-08T18:48:56.8811920Z Models: read
+Test (Rust on macos-latest)	Set up job	2026-01-08T18:48:56.8812210Z Packages: write
+Test (Rust on macos-latest)	Set up job	2026-01-08T18:48:56.8812510Z Pages: write
+Test (Rust on macos-latest)	Set up job	2026-01-08T18:48:56.8812800Z PullRequests: write
+Test (Rust on macos-latest)	Set up job	2026-01-08T18:48:56.8813160Z RepositoryProjects: write
+Test (Rust on macos-latest)	Set up job	2026-01-08T18:48:56.8813500Z SecurityEvents: write
+Test (Rust on macos-latest)	Set up job	2026-01-08T18:48:56.8813830Z Statuses: write
+Test (Rust on macos-latest)	Set up job	2026-01-08T18:48:56.8814130Z ##[endgroup]
+Test (Rust on macos-latest)	Set up job	2026-01-08T18:48:56.8815460Z Secret source: Actions
+Test (Rust on macos-latest)	Set up job	2026-01-08T18:48:56.8815860Z Prepare workflow directory
+Test (Rust on macos-latest)	Set up job	2026-01-08T18:48:56.9166800Z Prepare all required actions
+Test (Rust on macos-latest)	Set up job	2026-01-08T18:48:56.9221210Z Getting action download info
+Test (Rust on macos-latest)	Set up job	2026-01-08T18:48:57.1579900Z Download action repository 'actions/checkout@v4' (SHA:34e114876b0b11c390a56381ad16ebd13914f8d5)
+Test (Rust on macos-latest)	Set up job	2026-01-08T18:48:57.5776630Z Download action repository 'dtolnay/rust-toolchain@stable' (SHA:4be9e76fd7c4901c61fb841f559994984270fce7)
+Test (Rust on macos-latest)	Set up job	2026-01-08T18:48:58.5257220Z Download action repository 'actions/cache@v4' (SHA:0057852bfaa89a56745cba8c7296529d2fc39830)
+Test (Rust on macos-latest)	Set up job	2026-01-08T18:48:58.7764530Z Complete job name: Test (Rust on macos-latest)
+Test (Rust on macos-latest)	Run actions/checkout@v4	﻿2026-01-08T18:48:58.8228630Z ##[group]Run actions/checkout@v4
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.8229300Z with:
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.8229710Z   repository: link-foundation/lino-objects-codec
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.8230400Z   token: ***
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.8230710Z   ssh-strict: true
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.8231020Z   ssh-user: git
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.8231340Z   persist-credentials: true
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.8231730Z   clean: true
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.8232050Z   sparse-checkout-cone-mode: true
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.8232420Z   fetch-depth: 1
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.8232730Z   fetch-tags: false
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.8233040Z   show-progress: true
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.8233370Z   lfs: false
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.8233670Z   submodules: false
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.8233990Z   set-safe-directory: true
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.8234470Z env:
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.8234790Z   CARGO_TERM_COLOR: always
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.8235180Z   RUSTFLAGS: -Dwarnings
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.8235500Z ##[endgroup]
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:48:59.2373950Z Syncing repository: link-foundation/lino-objects-codec
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:48:59.2379420Z ##[group]Getting Git version info
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:48:59.2380400Z Working directory is '/Users/runner/work/lino-objects-codec/lino-objects-codec'
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:48:59.2386510Z [command]/opt/homebrew/bin/git version
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:48:59.2824810Z git version 2.52.0
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:48:59.2894400Z ##[endgroup]
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:48:59.2912710Z Copying '/Users/runner/.gitconfig' to '/Users/runner/work/_temp/13007fba-a9aa-423b-853d-289227d14fce/.gitconfig'
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:48:59.2933560Z Temporarily overriding HOME='/Users/runner/work/_temp/13007fba-a9aa-423b-853d-289227d14fce' before making global git config changes
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:48:59.2934950Z Adding repository directory to the temporary git global config as a safe directory
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:48:59.2948070Z [command]/opt/homebrew/bin/git config --global --add safe.directory /Users/runner/work/lino-objects-codec/lino-objects-codec
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:48:59.3098540Z Deleting the contents of '/Users/runner/work/lino-objects-codec/lino-objects-codec'
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:48:59.3102170Z ##[group]Initializing the repository
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:48:59.3107020Z [command]/opt/homebrew/bin/git init /Users/runner/work/lino-objects-codec/lino-objects-codec
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:48:59.3302760Z hint: Using 'master' as the name for the initial branch. This default branch name
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:48:59.3304070Z hint: will change to "main" in Git 3.0. To configure the initial branch name
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:48:59.3305100Z hint: to use in all of your new repositories, which will suppress this warning,
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:48:59.3305700Z hint: call:
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:48:59.3306010Z hint:
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:48:59.3306450Z hint: 	git config --global init.defaultBranch <name>
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:48:59.3306900Z hint:
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:48:59.3307330Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:48:59.3308010Z hint: 'development'. The just-created branch can be renamed via this command:
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:48:59.3308790Z hint:
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:48:59.3309080Z hint: 	git branch -m <name>
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:48:59.3309420Z hint:
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:48:59.3309890Z hint: Disable this message with "git config set advice.defaultBranchName false"
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:48:59.3315180Z Initialized empty Git repository in /Users/runner/work/lino-objects-codec/lino-objects-codec/.git/
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:48:59.3326370Z [command]/opt/homebrew/bin/git remote add origin https://github.com/link-foundation/lino-objects-codec
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:48:59.3440410Z ##[endgroup]
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:48:59.3442060Z ##[group]Disabling automatic garbage collection
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:48:59.3458190Z [command]/opt/homebrew/bin/git config --local gc.auto 0
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:48:59.3584620Z ##[endgroup]
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:48:59.3586760Z ##[group]Setting up auth
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:48:59.3589050Z [command]/opt/homebrew/bin/git config --local --name-only --get-regexp core\.sshCommand
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:48:59.3735550Z [command]/opt/homebrew/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:48:59.5000680Z [command]/opt/homebrew/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:48:59.5073580Z [command]/opt/homebrew/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:48:59.6262650Z [command]/opt/homebrew/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:48:59.6330670Z [command]/opt/homebrew/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:48:59.7945330Z [command]/opt/homebrew/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:48:59.8034730Z ##[endgroup]
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:48:59.8035610Z ##[group]Fetching the repository
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:48:59.8042380Z [command]/opt/homebrew/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +c79c77d68a90cadbd439c9613a7050501095c92d:refs/remotes/origin/main
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:49:00.7645060Z From https://github.com/link-foundation/lino-objects-codec
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:49:00.7648640Z  * [new ref]         c79c77d68a90cadbd439c9613a7050501095c92d -> origin/main
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:49:00.7771620Z ##[endgroup]
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:49:00.7775920Z ##[group]Determining the checkout info
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:49:00.7776800Z ##[endgroup]
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:49:00.7777450Z [command]/opt/homebrew/bin/git sparse-checkout disable
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:49:00.7879430Z [command]/opt/homebrew/bin/git config --local --unset-all extensions.worktreeConfig
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:49:00.7955140Z ##[group]Checking out the ref
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:49:00.7958300Z [command]/opt/homebrew/bin/git checkout --progress --force -B main refs/remotes/origin/main
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:49:00.8351550Z Switched to a new branch 'main'
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:49:00.8360940Z branch 'main' set up to track 'origin/main'.
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:49:00.8373060Z ##[endgroup]
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:49:00.8485920Z [command]/opt/homebrew/bin/git log -1 --format=%H
+Test (Rust on macos-latest)	Run actions/checkout@v4	2026-01-08T18:49:00.8571720Z c79c77d68a90cadbd439c9613a7050501095c92d
+Test (Rust on macos-latest)	Set up Rust	﻿2026-01-08T18:49:00.9103840Z ##[group]Run dtolnay/rust-toolchain@stable
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:00.9104580Z with:
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:00.9105040Z   toolchain: stable
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:00.9105550Z env:
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:00.9106070Z   CARGO_TERM_COLOR: always
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:00.9106680Z   RUSTFLAGS: -Dwarnings
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:00.9107260Z ##[endgroup]
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:00.9249530Z ##[group]Run : parse toolchain version
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:00.9250430Z [36;1m: parse toolchain version[0m
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:00.9269390Z [36;1mif [[ -z $toolchain ]]; then[0m
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:00.9270680Z [36;1m  # GitHub does not enforce `required: true` inputs itself. https://github.com/actions/runner/issues/1070[0m
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:00.9271950Z [36;1m  echo "'toolchain' is a required input" >&2[0m
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:00.9272630Z [36;1m  exit 1[0m
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:00.9273370Z [36;1melif [[ $toolchain =~ ^stable' '[0-9]+' '(year|month|week|day)s?' 'ago$ ]]; then[0m
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:00.9274290Z [36;1m  if [[ macOS == macOS ]]; then[0m
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:00.9275490Z [36;1m    echo "toolchain=1.$((($(date -v-$(sed 's/stable \([0-9]*\) \(.\).*/\1\2/' <<< $toolchain) +%s)/60/60/24-16569)/7/6))" >> $GITHUB_OUTPUT[0m
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:00.9276880Z [36;1m  else[0m
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:00.9277860Z [36;1m    echo "toolchain=1.$((($(date --date "${toolchain#stable }" +%s)/60/60/24-16569)/7/6))" >> $GITHUB_OUTPUT[0m
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:00.9278950Z [36;1m  fi[0m
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:00.9279640Z [36;1melif [[ $toolchain =~ ^stable' 'minus' '[0-9]+' 'releases?$ ]]; then[0m
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:00.9280850Z [36;1m  echo "toolchain=1.$((($(date +%s)/60/60/24-16569)/7/6-${toolchain//[^0-9]/}))" >> $GITHUB_OUTPUT[0m
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:00.9281930Z [36;1melif [[ $toolchain =~ ^1\.[0-9]+$ ]]; then[0m
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:00.9283150Z [36;1m  echo "toolchain=1.$((i=${toolchain#1.}, c=($(date +%s)/60/60/24-16569)/7/6, i+9*i*(10*i<=c)+90*i*(100*i<=c)))" >> $GITHUB_OUTPUT[0m
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:00.9284330Z [36;1melse[0m
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:00.9284870Z [36;1m  echo "toolchain=$toolchain" >> $GITHUB_OUTPUT[0m
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:00.9285570Z [36;1mfi[0m
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:00.9335610Z shell: /bin/bash --noprofile --norc -e -o pipefail {0}
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:00.9336360Z env:
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:00.9336780Z   CARGO_TERM_COLOR: always
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:00.9337310Z   RUSTFLAGS: -Dwarnings
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:00.9337790Z   toolchain: stable
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:00.9338220Z ##[endgroup]
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:00.9999630Z ##[group]Run : construct rustup command line
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.0000460Z [36;1m: construct rustup command line[0m
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.0001470Z [36;1mecho "targets=$(for t in ${targets//,/ }; do echo -n ' --target' $t; done)" >> $GITHUB_OUTPUT[0m
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.0002900Z [36;1mecho "components=$(for c in ${components//,/ }; do echo -n ' --component' $c; done)" >> $GITHUB_OUTPUT[0m
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.0004020Z [36;1mecho "downgrade=" >> $GITHUB_OUTPUT[0m
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.0041340Z shell: /bin/bash --noprofile --norc -e -o pipefail {0}
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.0042200Z env:
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.0042680Z   CARGO_TERM_COLOR: always
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.0043310Z   RUSTFLAGS: -Dwarnings
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.0043830Z   targets: 
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.0044250Z   components: 
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.0044690Z ##[endgroup]
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.0480360Z ##[group]Run : set $CARGO_HOME
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.0482150Z [36;1m: set $CARGO_HOME[0m
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.0483260Z [36;1mecho CARGO_HOME=${CARGO_HOME:-"$HOME/.cargo"} >> $GITHUB_ENV[0m
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.0518530Z shell: /bin/bash --noprofile --norc -e -o pipefail {0}
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.0519280Z env:
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.0519720Z   CARGO_TERM_COLOR: always
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.0520270Z   RUSTFLAGS: -Dwarnings
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.0520750Z ##[endgroup]
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.0953430Z ##[group]Run : install rustup if needed
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.0954270Z [36;1m: install rustup if needed[0m
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.0955360Z [36;1mif ! command -v rustup &>/dev/null; then[0m
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.0957130Z [36;1m  curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused --location --silent --show-error --fail https://sh.rustup.rs | sh -s -- --default-toolchain none -y[0m
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.0960770Z [36;1m  echo "$CARGO_HOME/bin" >> $GITHUB_PATH[0m
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.0961450Z [36;1mfi[0m
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.1020110Z shell: /bin/bash --noprofile --norc -e -o pipefail {0}
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.1020920Z env:
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.1021380Z   CARGO_TERM_COLOR: always
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.1021930Z   RUSTFLAGS: -Dwarnings
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.1022460Z   CARGO_HOME: /Users/runner/.cargo
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.1023030Z ##[endgroup]
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.1528220Z ##[group]Run rustup toolchain install stable --profile minimal --no-self-update
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.1529600Z [36;1mrustup toolchain install stable --profile minimal --no-self-update[0m
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.1581730Z shell: /bin/bash --noprofile --norc -e -o pipefail {0}
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.1582490Z env:
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.1582910Z   CARGO_TERM_COLOR: always
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.1583440Z   RUSTFLAGS: -Dwarnings
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.1583980Z   CARGO_HOME: /Users/runner/.cargo
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.1584570Z   RUSTUP_PERMIT_COPY_RENAME: 1
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.1585110Z ##[endgroup]
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.6251460Z info: syncing channel updates for 'stable-aarch64-apple-darwin'
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.6757120Z 
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.6862970Z info: self-update is disabled for this build of rustup
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.6864340Z   stable-aarch64-apple-darwin unchanged - rustc 1.92.0 (ded5c06cf 2025-12-08)
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.6868620Z info: any updates to rustup will need to be fetched with your system package manager
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.6869400Z 
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.6923530Z ##[group]Run rustup default stable
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.6924290Z [36;1mrustup default stable[0m
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.6963520Z shell: /bin/bash --noprofile --norc -e -o pipefail {0}
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.6964320Z env:
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.6964790Z   CARGO_TERM_COLOR: always
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.6965350Z   RUSTFLAGS: -Dwarnings
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.6965910Z   CARGO_HOME: /Users/runner/.cargo
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.6966500Z ##[endgroup]
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.7593420Z info: using existing install for 'stable-aarch64-apple-darwin'
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.7976720Z info: default toolchain set to 'stable-aarch64-apple-darwin'
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.7978510Z 
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.8085060Z   stable-aarch64-apple-darwin unchanged - rustc 1.92.0 (ded5c06cf 2025-12-08)
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.8089700Z 
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.8146860Z ##[group]Run : create cachekey
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.8147490Z [36;1m: create cachekey[0m
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.8148580Z [36;1mDATE=$(rustc +stable --version --verbose | sed -ne 's/^commit-date: \(20[0-9][0-9]\)-\([01][0-9]\)-\([0-3][0-9]\)$/\1\2\3/p')[0m
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.8150100Z [36;1mHASH=$(rustc +stable --version --verbose | sed -ne 's/^commit-hash: //p')[0m
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.8151240Z [36;1mecho "cachekey=$(echo $DATE$HASH | head -c12)" >> $GITHUB_OUTPUT[0m
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.8190490Z shell: /bin/bash --noprofile --norc -e -o pipefail {0}
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.8191270Z env:
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.8191740Z   CARGO_TERM_COLOR: always
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.8192380Z   RUSTFLAGS: -Dwarnings
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.8192890Z   CARGO_HOME: /Users/runner/.cargo
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.8193460Z ##[endgroup]
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.9617240Z ##[group]Run : disable incremental compilation
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.9618040Z [36;1m: disable incremental compilation[0m
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.9618320Z [36;1mif [ -z "${CARGO_INCREMENTAL+set}" ]; then[0m
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.9618600Z [36;1m  echo CARGO_INCREMENTAL=0 >> $GITHUB_ENV[0m
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.9618840Z [36;1mfi[0m
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.9656410Z shell: /bin/bash --noprofile --norc -e -o pipefail {0}
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.9656740Z env:
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.9656940Z   CARGO_TERM_COLOR: always
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.9657180Z   RUSTFLAGS: -Dwarnings
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.9657540Z   CARGO_HOME: /Users/runner/.cargo
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:01.9657780Z ##[endgroup]
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:02.0191140Z ##[group]Run : enable colors in Cargo output
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:02.0191690Z [36;1m: enable colors in Cargo output[0m
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:02.0192390Z [36;1mif [ -z "${CARGO_TERM_COLOR+set}" ]; then[0m
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:02.0192740Z [36;1m  echo CARGO_TERM_COLOR=always >> $GITHUB_ENV[0m
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:02.0192990Z [36;1mfi[0m
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:02.0231980Z shell: /bin/bash --noprofile --norc -e -o pipefail {0}
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:02.0232370Z env:
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:02.0232610Z   CARGO_TERM_COLOR: always
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:02.0232870Z   RUSTFLAGS: -Dwarnings
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:02.0233120Z   CARGO_HOME: /Users/runner/.cargo
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:02.0233420Z   CARGO_INCREMENTAL: 0
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:02.0233610Z ##[endgroup]
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:02.0714960Z ##[group]Run : enable Cargo sparse registry
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:02.0715430Z [36;1m: enable Cargo sparse registry[0m
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:02.0715760Z [36;1m# implemented in 1.66, stabilized in 1.68, made default in 1.70[0m
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:02.0716400Z [36;1mif [ -z "${CARGO_REGISTRIES_CRATES_IO_PROTOCOL+set}" -o -f "/Users/runner/work/_temp"/.implicit_cargo_registries_crates_io_protocol ]; then[0m
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:02.0717080Z [36;1m  if rustc +stable --version --verbose | grep -q '^release: 1\.6[89]\.'; then[0m
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:02.0717570Z [36;1m    touch "/Users/runner/work/_temp"/.implicit_cargo_registries_crates_io_protocol || true[0m
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:02.0718110Z [36;1m    echo CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse >> $GITHUB_ENV[0m
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:02.0719390Z [36;1m  elif rustc +stable --version --verbose | grep -q '^release: 1\.6[67]\.'; then[0m
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:02.0720920Z [36;1m    touch "/Users/runner/work/_temp"/.implicit_cargo_registries_crates_io_protocol || true[0m
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:02.0722180Z [36;1m    echo CARGO_REGISTRIES_CRATES_IO_PROTOCOL=git >> $GITHUB_ENV[0m
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:02.0722980Z [36;1m  fi[0m
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:02.0723560Z [36;1mfi[0m
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:02.0769100Z shell: /bin/bash --noprofile --norc -e -o pipefail {0}
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:02.0769430Z env:
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:02.0769600Z   CARGO_TERM_COLOR: always
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:02.0769820Z   RUSTFLAGS: -Dwarnings
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:02.0770050Z   CARGO_HOME: /Users/runner/.cargo
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:02.0770270Z   CARGO_INCREMENTAL: 0
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:02.0770450Z ##[endgroup]
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:02.1910900Z ##[group]Run : work around spurious network errors in curl 8.0
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:02.1911430Z [36;1m: work around spurious network errors in curl 8.0[0m
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:02.1912290Z [36;1m# https://rust-lang.zulipchat.com/#narrow/stream/246057-t-cargo/topic/timeout.20investigation[0m
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:02.1915900Z [36;1mif rustc +stable --version --verbose | grep -q '^release: 1\.7[01]\.'; then[0m
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:02.1917420Z [36;1m  echo CARGO_HTTP_MULTIPLEXING=false >> $GITHUB_ENV[0m
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:02.1918180Z [36;1mfi[0m
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:02.1959160Z shell: /bin/bash --noprofile --norc -e -o pipefail {0}
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:02.1959500Z env:
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:02.1959730Z   CARGO_TERM_COLOR: always
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:02.1959950Z   RUSTFLAGS: -Dwarnings
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:02.1960180Z   CARGO_HOME: /Users/runner/.cargo
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:02.1960480Z   CARGO_INCREMENTAL: 0
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:02.1960670Z ##[endgroup]
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:02.2722720Z ##[group]Run rustc +stable --version --verbose
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:02.2725050Z [36;1mrustc +stable --version --verbose[0m
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:02.2795450Z shell: /bin/bash --noprofile --norc -e -o pipefail {0}
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:02.2795860Z env:
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:02.2796050Z   CARGO_TERM_COLOR: always
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:02.2796250Z   RUSTFLAGS: -Dwarnings
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:02.2796460Z   CARGO_HOME: /Users/runner/.cargo
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:02.2796810Z   CARGO_INCREMENTAL: 0
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:02.2797030Z ##[endgroup]
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:02.3512510Z rustc 1.92.0 (ded5c06cf 2025-12-08)
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:02.3512960Z binary: rustc
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:02.3513250Z commit-hash: ded5c06cf21d2b93bffd5d884aa6e96934ee4234
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:02.3513590Z commit-date: 2025-12-08
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:02.3513810Z host: aarch64-apple-darwin
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:02.3514040Z release: 1.92.0
+Test (Rust on macos-latest)	Set up Rust	2026-01-08T18:49:02.3516770Z LLVM version: 21.1.3
+Test (Rust on macos-latest)	Cache cargo dependencies	﻿2026-01-08T18:49:02.4678070Z ##[group]Run actions/cache@v4
+Test (Rust on macos-latest)	Cache cargo dependencies	2026-01-08T18:49:02.4678350Z with:
+Test (Rust on macos-latest)	Cache cargo dependencies	2026-01-08T18:49:02.4678680Z   path: ~/.cargo/bin/
+Test (Rust on macos-latest)	Cache cargo dependencies	~/.cargo/registry/index/
+Test (Rust on macos-latest)	Cache cargo dependencies	~/.cargo/registry/cache/
+Test (Rust on macos-latest)	Cache cargo dependencies	~/.cargo/git/db/
+Test (Rust on macos-latest)	Cache cargo dependencies	rust/target/
+Test (Rust on macos-latest)	Cache cargo dependencies	
+Test (Rust on macos-latest)	Cache cargo dependencies	2026-01-08T18:49:02.4679270Z   key: macOS-cargo-3bdf1052f98aec50857f27e3615100242b9f9c1f98c417d8384cf7fd70b81aba
+Test (Rust on macos-latest)	Cache cargo dependencies	2026-01-08T18:49:02.4679640Z   enableCrossOsArchive: false
+Test (Rust on macos-latest)	Cache cargo dependencies	2026-01-08T18:49:02.4679840Z   fail-on-cache-miss: false
+Test (Rust on macos-latest)	Cache cargo dependencies	2026-01-08T18:49:02.4680030Z   lookup-only: false
+Test (Rust on macos-latest)	Cache cargo dependencies	2026-01-08T18:49:02.4680200Z   save-always: false
+Test (Rust on macos-latest)	Cache cargo dependencies	2026-01-08T18:49:02.4680360Z env:
+Test (Rust on macos-latest)	Cache cargo dependencies	2026-01-08T18:49:02.4680510Z   CARGO_TERM_COLOR: always
+Test (Rust on macos-latest)	Cache cargo dependencies	2026-01-08T18:49:02.4680710Z   RUSTFLAGS: -Dwarnings
+Test (Rust on macos-latest)	Cache cargo dependencies	2026-01-08T18:49:02.4680910Z   CARGO_HOME: /Users/runner/.cargo
+Test (Rust on macos-latest)	Cache cargo dependencies	2026-01-08T18:49:02.4681120Z   CARGO_INCREMENTAL: 0
+Test (Rust on macos-latest)	Cache cargo dependencies	2026-01-08T18:49:02.4681310Z ##[endgroup]
+Test (Rust on macos-latest)	Cache cargo dependencies	2026-01-08T18:49:02.7557480Z Cache hit for: macOS-cargo-3bdf1052f98aec50857f27e3615100242b9f9c1f98c417d8384cf7fd70b81aba
+Test (Rust on macos-latest)	Cache cargo dependencies	2026-01-08T18:49:02.9727310Z Received 8256669 of 8256669 (100.0%), 44.5 MBs/sec
+Test (Rust on macos-latest)	Cache cargo dependencies	2026-01-08T18:49:02.9735840Z Cache Size: ~8 MB (8256669 B)
+Test (Rust on macos-latest)	Cache cargo dependencies	2026-01-08T18:49:02.9765570Z [command]/opt/homebrew/bin/gtar -xf /Users/runner/work/_temp/8d7e9463-a583-4d64-bd0e-4741bc843f6b/cache.tzst -P -C /Users/runner/work/lino-objects-codec/lino-objects-codec --delay-directory-restore --use-compress-program unzstd
+Test (Rust on macos-latest)	Cache cargo dependencies	2026-01-08T18:49:03.2044490Z Cache restored successfully
+Test (Rust on macos-latest)	Cache cargo dependencies	2026-01-08T18:49:03.2632570Z Cache restored from key: macOS-cargo-3bdf1052f98aec50857f27e3615100242b9f9c1f98c417d8384cf7fd70b81aba
+Test (Rust on macos-latest)	Run tests	﻿2026-01-08T18:49:03.2748190Z ##[group]Run cargo test --verbose
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:03.2748640Z [36;1mcargo test --verbose[0m
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:03.2815220Z shell: /bin/bash -e {0}
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:03.2815500Z env:
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:03.2815670Z   CARGO_TERM_COLOR: always
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:03.2815910Z   RUSTFLAGS: -Dwarnings
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:03.2816140Z   CARGO_HOME: /Users/runner/.cargo
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:03.2816380Z   CARGO_INCREMENTAL: 0
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:03.2816590Z ##[endgroup]
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:03.7040500Z [1m[92m   Compiling[0m memchr v2.7.6
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:03.7046030Z [1m[92m   Compiling[0m base64 v0.22.1
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:03.7053070Z [1m[92m     Running[0m `/Users/runner/.rustup/toolchains/stable-aarch64-apple-darwin/bin/rustc --crate-name memchr --edition=2021 /Users/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/memchr-2.7.6/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debuginfo=2 -C split-debuginfo=unpacked --cfg 'feature="alloc"' --cfg 'feature="std"' --check-cfg 'cfg(docsrs,test)' --check-cfg 'cfg(feature, values("alloc", "core", "default", "libc", "logging", "rustc-dep-of-std", "std", "use_std"))' -C metadata=5961419d202c0f5e -C extra-filename=-9d4fafe6e10b3211 --out-dir /Users/runner/work/lino-objects-codec/lino-objects-codec/rust/target/debug/deps -L dependency=/Users/runner/work/lino-objects-codec/lino-objects-codec/rust/target/debug/deps --cap-lints allow -Dwarnings`
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:03.7058670Z [1m[92m     Running[0m `/Users/runner/.rustup/toolchains/stable-aarch64-apple-darwin/bin/rustc --crate-name base64 --edition=2018 /Users/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/base64-0.22.1/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debuginfo=2 -C split-debuginfo=unpacked --cfg 'feature="alloc"' --cfg 'feature="default"' --cfg 'feature="std"' --check-cfg 'cfg(docsrs,test)' --check-cfg 'cfg(feature, values("alloc", "default", "std"))' -C metadata=f57100b177c2b875 -C extra-filename=-79cc58f7ae133655 --out-dir /Users/runner/work/lino-objects-codec/lino-objects-codec/rust/target/debug/deps -L dependency=/Users/runner/work/lino-objects-codec/lino-objects-codec/rust/target/debug/deps --cap-lints allow -Dwarnings`
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:04.6738350Z [1m[92m   Compiling[0m nom v8.0.0
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:04.6743470Z [1m[92m     Running[0m `/Users/runner/.rustup/toolchains/stable-aarch64-apple-darwin/bin/rustc --crate-name nom --edition=2021 /Users/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nom-8.0.0/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debuginfo=2 -C split-debuginfo=unpacked --cfg 'feature="alloc"' --cfg 'feature="default"' --cfg 'feature="std"' --check-cfg 'cfg(docsrs,test)' --check-cfg 'cfg(feature, values("alloc", "default", "docsrs", "std"))' -C metadata=6249afa8cf2761e5 -C extra-filename=-90d1192dc2a9c615 --out-dir /Users/runner/work/lino-objects-codec/lino-objects-codec/rust/target/debug/deps -L dependency=/Users/runner/work/lino-objects-codec/lino-objects-codec/rust/target/debug/deps --extern memchr=/Users/runner/work/lino-objects-codec/lino-objects-codec/rust/target/debug/deps/libmemchr-9d4fafe6e10b3211.rmeta --cap-lints allow -Dwarnings`
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:07.3244010Z [1m[92m   Compiling[0m links-notation v0.13.0
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:07.3257440Z [1m[92m     Running[0m `/Users/runner/.rustup/toolchains/stable-aarch64-apple-darwin/bin/rustc --crate-name links_notation --edition=2021 /Users/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/links-notation-0.13.0/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debuginfo=2 -C split-debuginfo=unpacked --check-cfg 'cfg(docsrs,test)' --check-cfg 'cfg(feature, values())' -C metadata=e4a6e57b58886a31 -C extra-filename=-64366e86c5f1ca4d --out-dir /Users/runner/work/lino-objects-codec/lino-objects-codec/rust/target/debug/deps -L dependency=/Users/runner/work/lino-objects-codec/lino-objects-codec/rust/target/debug/deps --extern nom=/Users/runner/work/lino-objects-codec/lino-objects-codec/rust/target/debug/deps/libnom-90d1192dc2a9c615.rmeta --cap-lints allow -Dwarnings`
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:07.7442480Z [1m[92m   Compiling[0m lino-objects-codec v0.2.0 (/Users/runner/work/lino-objects-codec/lino-objects-codec/rust)
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:07.7477380Z [1m[92m     Running[0m `/Users/runner/.rustup/toolchains/stable-aarch64-apple-darwin/bin/rustc --crate-name lino_objects_codec --edition=2021 src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debuginfo=2 -C split-debuginfo=unpacked '--warn=clippy::pedantic' '--warn=clippy::nursery' '--warn=clippy::all' '--allow=clippy::use_self' '--allow=clippy::unused_self' '--allow=clippy::unreadable_literal' '--allow=clippy::uninlined_format_args' '--allow=clippy::too_many_lines' '--allow=clippy::similar_names' '--allow=clippy::redundant_closure_for_method_calls' '--allow=clippy::redundant_clone' '--allow=clippy::option_if_let_else' '--allow=clippy::must_use_candidate' '--allow=clippy::module_name_repetitions' '--allow=clippy::missing_panics_doc' '--allow=clippy::missing_errors_doc' '--allow=clippy::missing_const_for_fn' '--allow=clippy::inefficient_to_string' '--allow=clippy::ignored_unit_patterns' '--allow=clippy::if_not_else' '--allow=clippy::doc_markdown' '--allow=clippy::derive_partial_eq_without_eq' '--allow=clippy::cast_precision_loss' '--allow=clippy::cast_lossless' '--allow=clippy::assigning_clones' '--allow=clippy::approx_constant' --check-cfg 'cfg(docsrs,test)' --check-cfg 'cfg(feature, values())' -C metadata=b7d049be87ae6b7b -C extra-filename=-c7abdeb243da9eab --out-dir /Users/runner/work/lino-objects-codec/lino-objects-codec/rust/target/debug/deps -L dependency=/Users/runner/work/lino-objects-codec/lino-objects-codec/rust/target/debug/deps --extern base64=/Users/runner/work/lino-objects-codec/lino-objects-codec/rust/target/debug/deps/libbase64-79cc58f7ae133655.rmeta --extern links_notation=/Users/runner/work/lino-objects-codec/lino-objects-codec/rust/target/debug/deps/liblinks_notation-64366e86c5f1ca4d.rmeta -Dwarnings`
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:08.1553910Z [1m[92m     Running[0m `/Users/runner/.rustup/toolchains/stable-aarch64-apple-darwin/bin/rustc --crate-name lino_objects_codec --edition=2021 src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --emit=dep-info,link -C embed-bitcode=no -C debuginfo=2 -C split-debuginfo=unpacked '--warn=clippy::pedantic' '--warn=clippy::nursery' '--warn=clippy::all' '--allow=clippy::use_self' '--allow=clippy::unused_self' '--allow=clippy::unreadable_literal' '--allow=clippy::uninlined_format_args' '--allow=clippy::too_many_lines' '--allow=clippy::similar_names' '--allow=clippy::redundant_closure_for_method_calls' '--allow=clippy::redundant_clone' '--allow=clippy::option_if_let_else' '--allow=clippy::must_use_candidate' '--allow=clippy::module_name_repetitions' '--allow=clippy::missing_panics_doc' '--allow=clippy::missing_errors_doc' '--allow=clippy::missing_const_for_fn' '--allow=clippy::inefficient_to_string' '--allow=clippy::ignored_unit_patterns' '--allow=clippy::if_not_else' '--allow=clippy::doc_markdown' '--allow=clippy::derive_partial_eq_without_eq' '--allow=clippy::cast_precision_loss' '--allow=clippy::cast_lossless' '--allow=clippy::assigning_clones' '--allow=clippy::approx_constant' --test --check-cfg 'cfg(docsrs,test)' --check-cfg 'cfg(feature, values())' -C metadata=96b7b4da234d00a2 -C extra-filename=-e4559b4b325c137a --out-dir /Users/runner/work/lino-objects-codec/lino-objects-codec/rust/target/debug/deps -L dependency=/Users/runner/work/lino-objects-codec/lino-objects-codec/rust/target/debug/deps --extern base64=/Users/runner/work/lino-objects-codec/lino-objects-codec/rust/target/debug/deps/libbase64-79cc58f7ae133655.rlib --extern links_notation=/Users/runner/work/lino-objects-codec/lino-objects-codec/rust/target/debug/deps/liblinks_notation-64366e86c5f1ca4d.rlib -Dwarnings`
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:08.6287110Z [1m[92m     Running[0m `/Users/runner/.rustup/toolchains/stable-aarch64-apple-darwin/bin/rustc --crate-name basic_usage --edition=2021 examples/basic_usage.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --crate-type bin --emit=dep-info,link -C embed-bitcode=no -C debuginfo=2 -C split-debuginfo=unpacked '--warn=clippy::pedantic' '--warn=clippy::nursery' '--warn=clippy::all' '--allow=clippy::use_self' '--allow=clippy::unused_self' '--allow=clippy::unreadable_literal' '--allow=clippy::uninlined_format_args' '--allow=clippy::too_many_lines' '--allow=clippy::similar_names' '--allow=clippy::redundant_closure_for_method_calls' '--allow=clippy::redundant_clone' '--allow=clippy::option_if_let_else' '--allow=clippy::must_use_candidate' '--allow=clippy::module_name_repetitions' '--allow=clippy::missing_panics_doc' '--allow=clippy::missing_errors_doc' '--allow=clippy::missing_const_for_fn' '--allow=clippy::inefficient_to_string' '--allow=clippy::ignored_unit_patterns' '--allow=clippy::if_not_else' '--allow=clippy::doc_markdown' '--allow=clippy::derive_partial_eq_without_eq' '--allow=clippy::cast_precision_loss' '--allow=clippy::cast_lossless' '--allow=clippy::assigning_clones' '--allow=clippy::approx_constant' --check-cfg 'cfg(docsrs,test)' --check-cfg 'cfg(feature, values())' -C metadata=945da2b926e1bc41 -C extra-filename=-6fface4f1c10c2b6 --out-dir /Users/runner/work/lino-objects-codec/lino-objects-codec/rust/target/debug/examples -L dependency=/Users/runner/work/lino-objects-codec/lino-objects-codec/rust/target/debug/deps --extern base64=/Users/runner/work/lino-objects-codec/lino-objects-codec/rust/target/debug/deps/libbase64-79cc58f7ae133655.rlib --extern links_notation=/Users/runner/work/lino-objects-codec/lino-objects-codec/rust/target/debug/deps/liblinks_notation-64366e86c5f1ca4d.rlib --extern lino_objects_codec=/Users/runner/work/lino-objects-codec/lino-objects-codec/rust/target/debug/deps/liblino_objects_codec-c7abdeb243da9eab.rlib -Dwarnings`
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:13.1958010Z [1m[92m    Finished[0m `test` profile [unoptimized + debuginfo] target(s) in 9.76s
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:13.2035590Z [1m[92m     Running[0m `/Users/runner/work/lino-objects-codec/lino-objects-codec/rust/target/debug/deps/lino_objects_codec-e4559b4b325c137a`
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:13.2138080Z [1m[92m   Doc-tests[0m lino_objects_codec
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:13.2138400Z 
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:13.2186100Z [1m[92m     Running[0m `/Users/runner/.rustup/toolchains/stable-aarch64-apple-darwin/bin/rustdoc --edition=2021 --crate-type lib --color always --crate-name lino_objects_codec --test src/lib.rs --test-run-directory /Users/runner/work/lino-objects-codec/lino-objects-codec/rust -L dependency=/Users/runner/work/lino-objects-codec/lino-objects-codec/rust/target/debug/deps -L dependency=/Users/runner/work/lino-objects-codec/lino-objects-codec/rust/target/debug/deps '--warn=clippy::pedantic' '--warn=clippy::nursery' '--warn=clippy::all' '--allow=clippy::use_self' '--allow=clippy::unused_self' '--allow=clippy::unreadable_literal' '--allow=clippy::uninlined_format_args' '--allow=clippy::too_many_lines' '--allow=clippy::similar_names' '--allow=clippy::redundant_closure_for_method_calls' '--allow=clippy::redundant_clone' '--allow=clippy::option_if_let_else' '--allow=clippy::must_use_candidate' '--allow=clippy::module_name_repetitions' '--allow=clippy::missing_panics_doc' '--allow=clippy::missing_errors_doc' '--allow=clippy::missing_const_for_fn' '--allow=clippy::inefficient_to_string' '--allow=clippy::ignored_unit_patterns' '--allow=clippy::if_not_else' '--allow=clippy::doc_markdown' '--allow=clippy::derive_partial_eq_without_eq' '--allow=clippy::cast_precision_loss' '--allow=clippy::cast_lossless' '--allow=clippy::assigning_clones' '--allow=clippy::approx_constant' --extern base64=/Users/runner/work/lino-objects-codec/lino-objects-codec/rust/target/debug/deps/libbase64-79cc58f7ae133655.rlib --extern links_notation=/Users/runner/work/lino-objects-codec/lino-objects-codec/rust/target/debug/deps/liblinks_notation-64366e86c5f1ca4d.rlib --extern lino_objects_codec=/Users/runner/work/lino-objects-codec/lino-objects-codec/rust/target/debug/deps/liblino_objects_codec-c7abdeb243da9eab.rlib -C embed-bitcode=no --check-cfg 'cfg(docsrs,test)' --check-cfg 'cfg(feature, values())' --error-format human`
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:13.2219330Z running 32 tests
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:13.2233130Z test format_tests::test_escape_reference_simple_string ... ok
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:13.2235360Z test format_tests::test_escape_reference_string_with_double_quotes ... ok
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:13.2239130Z test format_tests::test_escape_reference_string_with_single_quotes ... ok
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:13.2240700Z test format_tests::test_escape_reference_string_with_spaces ... ok
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:13.2245190Z test format_tests::test_format_indented_ordered_basic ... ok
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:13.2253160Z test format_tests::test_format_indented_value_with_quotes ... ok
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:13.2254960Z test format_tests::test_format_indented_requires_id ... ok
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:13.2256390Z test format_tests::test_parse_indented_basic ... ok
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:13.2256800Z test format_tests::test_parse_indented_requires_text ... ok
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:13.2257260Z test format_tests::test_parse_indented_with_quotes ... ok
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:13.2257830Z test format_tests::test_parse_indented_empty_lines_skipped ... ok
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:13.2259290Z test format_tests::test_roundtrip_format_indented ... ok
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:13.2260450Z test format_tests::test_unescape_reference_doubled_quotes ... ok
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:13.2261710Z test format_tests::test_roundtrip_with_quotes ... ok
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:13.2262040Z test tests::test_dict_of_lists ... ok
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:13.2265630Z test tests::test_float_special_values ... ok
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:13.2266520Z test tests::test_complex_structure ... ok
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:13.2267190Z test tests::test_list_of_dicts ... ok
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:13.2269270Z test tests::test_nested_arrays ... ok
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:13.2270700Z test tests::test_roundtrip_bool ... ok
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:13.2272190Z test tests::test_roundtrip_empty_array ... ok
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:13.2273540Z test tests::test_nested_objects ... ok
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:13.2274940Z test tests::test_roundtrip_empty_object ... ok
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:13.2275910Z test tests::test_roundtrip_int ... ok
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:13.2276850Z test tests::test_roundtrip_float ... ok
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:13.2277850Z test tests::test_roundtrip_mixed_array ... ok
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:13.2278240Z test tests::test_roundtrip_null ... ok
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:13.2278540Z test tests::test_roundtrip_simple_array ... ok
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:13.2279600Z test tests::test_roundtrip_simple_object ... ok
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:13.2279910Z test tests::test_roundtrip_string ... ok
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:13.2281480Z test tests::test_string_with_quotes ... ok
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:13.2284200Z test tests::test_unicode_string ... ok
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:13.2284590Z 
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:13.2285200Z test result: ok. 32 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:13.2286940Z 
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:13.3604070Z 
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:13.3722540Z running 5 tests
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:13.6364670Z test src/lib.rs - decode (line 887) ... ok
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:13.6466130Z test src/lib.rs - encode (line 858) ... ok
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:13.8633570Z test src/lib.rs - format::format_indented (line 1043) ... ok
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:13.8736010Z test src/lib.rs - format::parse_indented (line 1139) ... ok
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:13.8992290Z test src/lib.rs - (line 19) ... ok
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:13.8992590Z 
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:13.8992820Z test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.54s
+Test (Rust on macos-latest)	Run tests	2026-01-08T18:49:13.8993160Z 
+Test (Rust on macos-latest)	Run doc tests	﻿2026-01-08T18:49:13.9296540Z ##[group]Run cargo test --doc --verbose
+Test (Rust on macos-latest)	Run doc tests	2026-01-08T18:49:13.9297490Z [36;1mcargo test --doc --verbose[0m
+Test (Rust on macos-latest)	Run doc tests	2026-01-08T18:49:13.9394380Z shell: /bin/bash -e {0}
+Test (Rust on macos-latest)	Run doc tests	2026-01-08T18:49:13.9394640Z env:
+Test (Rust on macos-latest)	Run doc tests	2026-01-08T18:49:13.9394920Z   CARGO_TERM_COLOR: always
+Test (Rust on macos-latest)	Run doc tests	2026-01-08T18:49:13.9395150Z   RUSTFLAGS: -Dwarnings
+Test (Rust on macos-latest)	Run doc tests	2026-01-08T18:49:13.9395440Z   CARGO_HOME: /Users/runner/.cargo
+Test (Rust on macos-latest)	Run doc tests	2026-01-08T18:49:13.9395680Z   CARGO_INCREMENTAL: 0
+Test (Rust on macos-latest)	Run doc tests	2026-01-08T18:49:13.9395880Z ##[endgroup]
+Test (Rust on macos-latest)	Run doc tests	2026-01-08T18:49:14.1802970Z [1m[92m       Fresh[0m memchr v2.7.6
+Test (Rust on macos-latest)	Run doc tests	2026-01-08T18:49:14.1803860Z [1m[92m       Fresh[0m nom v8.0.0
+Test (Rust on macos-latest)	Run doc tests	2026-01-08T18:49:14.1804280Z [1m[92m       Fresh[0m base64 v0.22.1
+Test (Rust on macos-latest)	Run doc tests	2026-01-08T18:49:14.1804920Z [1m[92m       Fresh[0m links-notation v0.13.0
+Test (Rust on macos-latest)	Run doc tests	2026-01-08T18:49:14.1805550Z [1m[92m       Fresh[0m lino-objects-codec v0.2.0 (/Users/runner/work/lino-objects-codec/lino-objects-codec/rust)
+Test (Rust on macos-latest)	Run doc tests	2026-01-08T18:49:14.1806250Z [1m[92m    Finished[0m `test` profile [unoptimized + debuginfo] target(s) in 0.03s
+Test (Rust on macos-latest)	Run doc tests	2026-01-08T18:49:14.1806830Z [1m[92m   Doc-tests[0m lino_objects_codec
+Test (Rust on macos-latest)	Run doc tests	2026-01-08T18:49:14.1813110Z [1m[92m     Running[0m `/Users/runner/.rustup/toolchains/stable-aarch64-apple-darwin/bin/rustdoc --edition=2021 --crate-type lib --color always --crate-name lino_objects_codec --test src/lib.rs --test-run-directory /Users/runner/work/lino-objects-codec/lino-objects-codec/rust -L dependency=/Users/runner/work/lino-objects-codec/lino-objects-codec/rust/target/debug/deps -L dependency=/Users/runner/work/lino-objects-codec/lino-objects-codec/rust/target/debug/deps '--warn=clippy::pedantic' '--warn=clippy::nursery' '--warn=clippy::all' '--allow=clippy::use_self' '--allow=clippy::unused_self' '--allow=clippy::unreadable_literal' '--allow=clippy::uninlined_format_args' '--allow=clippy::too_many_lines' '--allow=clippy::similar_names' '--allow=clippy::redundant_closure_for_method_calls' '--allow=clippy::redundant_clone' '--allow=clippy::option_if_let_else' '--allow=clippy::must_use_candidate' '--allow=clippy::module_name_repetitions' '--allow=clippy::missing_panics_doc' '--allow=clippy::missing_errors_doc' '--allow=clippy::missing_const_for_fn' '--allow=clippy::inefficient_to_string' '--allow=clippy::ignored_unit_patterns' '--allow=clippy::if_not_else' '--allow=clippy::doc_markdown' '--allow=clippy::derive_partial_eq_without_eq' '--allow=clippy::cast_precision_loss' '--allow=clippy::cast_lossless' '--allow=clippy::assigning_clones' '--allow=clippy::approx_constant' --extern base64=/Users/runner/work/lino-objects-codec/lino-objects-codec/rust/target/debug/deps/libbase64-79cc58f7ae133655.rlib --extern links_notation=/Users/runner/work/lino-objects-codec/lino-objects-codec/rust/target/debug/deps/liblinks_notation-64366e86c5f1ca4d.rlib --extern lino_objects_codec=/Users/runner/work/lino-objects-codec/lino-objects-codec/rust/target/debug/deps/liblino_objects_codec-c7abdeb243da9eab.rlib -C embed-bitcode=no --check-cfg 'cfg(docsrs,test)' --check-cfg 'cfg(feature, values())' --error-format human`
+Test (Rust on macos-latest)	Run doc tests	2026-01-08T18:49:14.2195770Z 
+Test (Rust on macos-latest)	Run doc tests	2026-01-08T18:49:14.2316670Z running 5 tests
+Test (Rust on macos-latest)	Run doc tests	2026-01-08T18:49:14.5229620Z test src/lib.rs - encode (line 858) ... ok
+Test (Rust on macos-latest)	Run doc tests	2026-01-08T18:49:14.5335290Z test src/lib.rs - (line 19) ... ok
+Test (Rust on macos-latest)	Run doc tests	2026-01-08T18:49:14.5437540Z test src/lib.rs - decode (line 887) ... ok
+Test (Rust on macos-latest)	Run doc tests	2026-01-08T18:49:14.7439510Z test src/lib.rs - format::format_indented (line 1043) ... ok
+Test (Rust on macos-latest)	Run doc tests	2026-01-08T18:49:14.7632270Z test src/lib.rs - format::parse_indented (line 1139) ... ok
+Test (Rust on macos-latest)	Run doc tests	2026-01-08T18:49:14.7736200Z 
+Test (Rust on macos-latest)	Run doc tests	2026-01-08T18:49:14.7761220Z test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.54s
+Test (Rust on macos-latest)	Run doc tests	2026-01-08T18:49:14.7762010Z 
+Test (Rust on macos-latest)	Run example	﻿2026-01-08T18:49:14.7792940Z ##[group]Run cargo run --example basic_usage
+Test (Rust on macos-latest)	Run example	2026-01-08T18:49:14.7793300Z [36;1mcargo run --example basic_usage[0m
+Test (Rust on macos-latest)	Run example	2026-01-08T18:49:14.7857940Z shell: /bin/bash -e {0}
+Test (Rust on macos-latest)	Run example	2026-01-08T18:49:14.7858210Z env:
+Test (Rust on macos-latest)	Run example	2026-01-08T18:49:14.7858540Z   CARGO_TERM_COLOR: always
+Test (Rust on macos-latest)	Run example	2026-01-08T18:49:14.7858820Z   RUSTFLAGS: -Dwarnings
+Test (Rust on macos-latest)	Run example	2026-01-08T18:49:14.7859050Z   CARGO_HOME: /Users/runner/.cargo
+Test (Rust on macos-latest)	Run example	2026-01-08T18:49:14.7859320Z   CARGO_INCREMENTAL: 0
+Test (Rust on macos-latest)	Run example	2026-01-08T18:49:14.7859550Z ##[endgroup]
+Test (Rust on macos-latest)	Run example	2026-01-08T18:49:14.9674330Z [1m[92m    Finished[0m `dev` profile [unoptimized + debuginfo] target(s) in 0.04s
+Test (Rust on macos-latest)	Run example	2026-01-08T18:49:14.9777060Z [1m[92m     Running[0m `target/debug/examples/basic_usage`
+Test (Rust on macos-latest)	Run example	2026-01-08T18:49:15.0246570Z === Links Notation Objects Codec - Rust Example ===
+Test (Rust on macos-latest)	Run example	2026-01-08T18:49:15.0375120Z 
+Test (Rust on macos-latest)	Run example	2026-01-08T18:49:15.0437600Z 1. Basic Types:
+Test (Rust on macos-latest)	Run example	2026-01-08T18:49:15.0567380Z    Null: (null) -> decoded: Null
+Test (Rust on macos-latest)	Run example	2026-01-08T18:49:15.0594470Z    true: (bool true) -> decoded: Bool(true)
+Test (Rust on macos-latest)	Run example	2026-01-08T18:49:15.0640730Z    42: (int 42) -> decoded: Int(42)
+Test (Rust on macos-latest)	Run example	2026-01-08T18:49:15.0673720Z    3.14159: (float 3.14159) -> decoded: Float(3.14159)
+Test (Rust on macos-latest)	Run example	2026-01-08T18:49:15.0680570Z    Infinity: (float Infinity) -> decoded: Float(inf)
+Test (Rust on macos-latest)	Run example	2026-01-08T18:49:15.0785860Z    NaN: (float NaN) -> decoded is_nan: true
+Test (Rust on macos-latest)	Run example	2026-01-08T18:49:15.0789430Z    'Hello, World!': (str SGVsbG8sIFdvcmxkIQ==) -> decoded: String("Hello, World!")
+Test (Rust on macos-latest)	Run example	2026-01-08T18:49:15.0821640Z    Unicode: (str 5L2g5aW95LiW55WMIPCfjI0=) -> decoded: String("你好世界 🌍")
+Test (Rust on macos-latest)	Run example	2026-01-08T18:49:15.0825520Z 
+Test (Rust on macos-latest)	Run example	2026-01-08T18:49:15.0825750Z 2. Collections:
+Test (Rust on macos-latest)	Run example	2026-01-08T18:49:15.0826220Z    Array [1, 2, 3]: (array (int 1) (int 2) (int 3))
+Test (Rust on macos-latest)	Run example	2026-01-08T18:49:15.0826660Z    Decoded: Array([Int(1), Int(2), Int(3)])
+Test (Rust on macos-latest)	Run example	2026-01-08T18:49:15.0827260Z    Object {name, age, active}: (object ((str bmFtZQ==) (str QWxpY2U=)) ((str YWdl) (int 30)) ((str YWN0aXZl) (bool true)))
+Test (Rust on macos-latest)	Run example	2026-01-08T18:49:15.0828090Z    Decoded: Object([("name", String("Alice")), ("age", Int(30)), ("active", Bool(true))])
+Test (Rust on macos-latest)	Run example	2026-01-08T18:49:15.0828470Z 
+Test (Rust on macos-latest)	Run example	2026-01-08T18:49:15.0828690Z 3. Nested Structure:
+Test (Rust on macos-latest)	Run example	2026-01-08T18:49:15.0829660Z    Encoded: (object ((str aWQ=) (int 123)) ((str bmFtZQ==) (str VGVzdCBPYmplY3Q=)) ((str dGFncw==) (array (str dGFnMQ==) (str dGFnMg==))) ((str bWV0YWRhdGE=) (object ((str dmVyc2lvbg==) (int 1)) ((str Y3JlYXRlZA==) (str MjAyNS0wMS0wMQ==)))))
+Test (Rust on macos-latest)	Run example	2026-01-08T18:49:15.0914360Z    Decoded name: Some(String("Test Object"))
+Test (Rust on macos-latest)	Run example	2026-01-08T18:49:15.0916980Z    Decoded tags: Some(Array([String("tag1"), String("tag2")]))
+Test (Rust on macos-latest)	Run example	2026-01-08T18:49:15.0917810Z    Decoded metadata.version: Some(Int(1))
+Test (Rust on macos-latest)	Run example	2026-01-08T18:49:15.0918640Z 
+Test (Rust on macos-latest)	Run example	2026-01-08T18:49:15.0918910Z 4. Mixed Type Array:
+Test (Rust on macos-latest)	Run example	2026-01-08T18:49:15.0919210Z    Encoded: (array (int 1) (str aGVsbG8=) (bool true) (null) (float 2.5))
+Test (Rust on macos-latest)	Run example	2026-01-08T18:49:15.0919850Z    Decoded: Array([Int(1), String("hello"), Bool(true), Null, Float(2.5)])
+Test (Rust on macos-latest)	Run example	2026-01-08T18:49:15.0921940Z 
+Test (Rust on macos-latest)	Run example	2026-01-08T18:49:15.0922670Z 5. Roundtrip Verification:
+Test (Rust on macos-latest)	Run example	2026-01-08T18:49:15.0923430Z    Original == Decoded: true
+Test (Rust on macos-latest)	Run example	2026-01-08T18:49:15.0923830Z 
+Test (Rust on macos-latest)	Run example	2026-01-08T18:49:15.0923910Z === Example completed successfully! ===
+Test (Rust on macos-latest)	Post Cache cargo dependencies	﻿2026-01-08T18:49:15.4918520Z Post job cleanup.
+Test (Rust on macos-latest)	Post Cache cargo dependencies	2026-01-08T18:49:15.7379420Z Cache hit occurred on the primary key macOS-cargo-3bdf1052f98aec50857f27e3615100242b9f9c1f98c417d8384cf7fd70b81aba, not saving cache.
+Test (Rust on macos-latest)	Post Run actions/checkout@v4	﻿2026-01-08T18:49:15.7547000Z Post job cleanup.
+Test (Rust on macos-latest)	Post Run actions/checkout@v4	2026-01-08T18:49:15.9274070Z [command]/opt/homebrew/bin/git version
+Test (Rust on macos-latest)	Post Run actions/checkout@v4	2026-01-08T18:49:15.9572800Z git version 2.52.0
+Test (Rust on macos-latest)	Post Run actions/checkout@v4	2026-01-08T18:49:15.9643570Z Copying '/Users/runner/.gitconfig' to '/Users/runner/work/_temp/9831efb6-4d33-4e60-95d3-bd839fab8fab/.gitconfig'
+Test (Rust on macos-latest)	Post Run actions/checkout@v4	2026-01-08T18:49:15.9665360Z Temporarily overriding HOME='/Users/runner/work/_temp/9831efb6-4d33-4e60-95d3-bd839fab8fab' before making global git config changes
+Test (Rust on macos-latest)	Post Run actions/checkout@v4	2026-01-08T18:49:15.9673180Z Adding repository directory to the temporary git global config as a safe directory
+Test (Rust on macos-latest)	Post Run actions/checkout@v4	2026-01-08T18:49:15.9674820Z [command]/opt/homebrew/bin/git config --global --add safe.directory /Users/runner/work/lino-objects-codec/lino-objects-codec
+Test (Rust on macos-latest)	Post Run actions/checkout@v4	2026-01-08T18:49:15.9839300Z [command]/opt/homebrew/bin/git config --local --name-only --get-regexp core\.sshCommand
+Test (Rust on macos-latest)	Post Run actions/checkout@v4	2026-01-08T18:49:15.9977130Z [command]/opt/homebrew/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+Test (Rust on macos-latest)	Post Run actions/checkout@v4	2026-01-08T18:49:16.1785210Z [command]/opt/homebrew/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Test (Rust on macos-latest)	Post Run actions/checkout@v4	2026-01-08T18:49:16.1801850Z http.https://github.com/.extraheader
+Test (Rust on macos-latest)	Post Run actions/checkout@v4	2026-01-08T18:49:16.1811760Z [command]/opt/homebrew/bin/git config --local --unset-all http.https://github.com/.extraheader
+Test (Rust on macos-latest)	Post Run actions/checkout@v4	2026-01-08T18:49:16.1891140Z [command]/opt/homebrew/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+Test (Rust on macos-latest)	Post Run actions/checkout@v4	2026-01-08T18:49:16.3439720Z [command]/opt/homebrew/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+Test (Rust on macos-latest)	Post Run actions/checkout@v4	2026-01-08T18:49:16.3743160Z [command]/opt/homebrew/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+Test (Rust on macos-latest)	Complete job	﻿2026-01-08T18:49:16.5277610Z Cleaning up orphan processes
+Test (Rust on windows-latest)	Set up job	﻿2026-01-08T18:48:57.1942380Z Current runner version: '2.330.0'
+Test (Rust on windows-latest)	Set up job	2026-01-08T18:48:57.1986991Z ##[group]Runner Image Provisioner
+Test (Rust on windows-latest)	Set up job	2026-01-08T18:48:57.1987720Z Hosted Compute Agent
+Test (Rust on windows-latest)	Set up job	2026-01-08T18:48:57.1988221Z Version: 20251211.462
+Test (Rust on windows-latest)	Set up job	2026-01-08T18:48:57.1989084Z Commit: 6cbad8c2bb55d58165063d031ccabf57e2d2db61
+Test (Rust on windows-latest)	Set up job	2026-01-08T18:48:57.1989698Z Build Date: 2025-12-11T16:28:49Z
+Test (Rust on windows-latest)	Set up job	2026-01-08T18:48:57.1990287Z Worker ID: {8f7a7bbb-f353-4621-af18-dc30970f188d}
+Test (Rust on windows-latest)	Set up job	2026-01-08T18:48:57.1990861Z ##[endgroup]
+Test (Rust on windows-latest)	Set up job	2026-01-08T18:48:57.1991313Z ##[group]Operating System
+Test (Rust on windows-latest)	Set up job	2026-01-08T18:48:57.1991816Z Microsoft Windows Server 2025
+Test (Rust on windows-latest)	Set up job	2026-01-08T18:48:57.1992322Z 10.0.26100
+Test (Rust on windows-latest)	Set up job	2026-01-08T18:48:57.1992716Z Datacenter
+Test (Rust on windows-latest)	Set up job	2026-01-08T18:48:57.1993133Z ##[endgroup]
+Test (Rust on windows-latest)	Set up job	2026-01-08T18:48:57.1993553Z ##[group]Runner Image
+Test (Rust on windows-latest)	Set up job	2026-01-08T18:48:57.1993980Z Image: windows-2025
+Test (Rust on windows-latest)	Set up job	2026-01-08T18:48:57.1994446Z Version: 20251216.149.1
+Test (Rust on windows-latest)	Set up job	2026-01-08T18:48:57.1995334Z Included Software: https://github.com/actions/runner-images/blob/win25/20251216.149/images/windows/Windows2025-Readme.md
+Test (Rust on windows-latest)	Set up job	2026-01-08T18:48:57.1997026Z Image Release: https://github.com/actions/runner-images/releases/tag/win25%2F20251216.149
+Test (Rust on windows-latest)	Set up job	2026-01-08T18:48:57.1997860Z ##[endgroup]
+Test (Rust on windows-latest)	Set up job	2026-01-08T18:48:57.2000602Z ##[group]GITHUB_TOKEN Permissions
+Test (Rust on windows-latest)	Set up job	2026-01-08T18:48:57.2002858Z Actions: write
+Test (Rust on windows-latest)	Set up job	2026-01-08T18:48:57.2003365Z ArtifactMetadata: write
+Test (Rust on windows-latest)	Set up job	2026-01-08T18:48:57.2003863Z Attestations: write
+Test (Rust on windows-latest)	Set up job	2026-01-08T18:48:57.2004312Z Checks: write
+Test (Rust on windows-latest)	Set up job	2026-01-08T18:48:57.2004700Z Contents: write
+Test (Rust on windows-latest)	Set up job	2026-01-08T18:48:57.2005139Z Deployments: write
+Test (Rust on windows-latest)	Set up job	2026-01-08T18:48:57.2005544Z Discussions: write
+Test (Rust on windows-latest)	Set up job	2026-01-08T18:48:57.2005970Z Issues: write
+Test (Rust on windows-latest)	Set up job	2026-01-08T18:48:57.2006359Z Metadata: read
+Test (Rust on windows-latest)	Set up job	2026-01-08T18:48:57.2006783Z Models: read
+Test (Rust on windows-latest)	Set up job	2026-01-08T18:48:57.2007197Z Packages: write
+Test (Rust on windows-latest)	Set up job	2026-01-08T18:48:57.2007593Z Pages: write
+Test (Rust on windows-latest)	Set up job	2026-01-08T18:48:57.2008054Z PullRequests: write
+Test (Rust on windows-latest)	Set up job	2026-01-08T18:48:57.2008540Z RepositoryProjects: write
+Test (Rust on windows-latest)	Set up job	2026-01-08T18:48:57.2009320Z SecurityEvents: write
+Test (Rust on windows-latest)	Set up job	2026-01-08T18:48:57.2009780Z Statuses: write
+Test (Rust on windows-latest)	Set up job	2026-01-08T18:48:57.2010205Z ##[endgroup]
+Test (Rust on windows-latest)	Set up job	2026-01-08T18:48:57.2012791Z Secret source: Actions
+Test (Rust on windows-latest)	Set up job	2026-01-08T18:48:57.2013442Z Prepare workflow directory
+Test (Rust on windows-latest)	Set up job	2026-01-08T18:48:57.2466348Z Prepare all required actions
+Test (Rust on windows-latest)	Set up job	2026-01-08T18:48:57.2523221Z Getting action download info
+Test (Rust on windows-latest)	Set up job	2026-01-08T18:48:57.6647908Z Download action repository 'actions/checkout@v4' (SHA:34e114876b0b11c390a56381ad16ebd13914f8d5)
+Test (Rust on windows-latest)	Set up job	2026-01-08T18:48:57.7986855Z Download action repository 'dtolnay/rust-toolchain@stable' (SHA:4be9e76fd7c4901c61fb841f559994984270fce7)
+Test (Rust on windows-latest)	Set up job	2026-01-08T18:48:58.2855408Z Download action repository 'actions/cache@v4' (SHA:0057852bfaa89a56745cba8c7296529d2fc39830)
+Test (Rust on windows-latest)	Set up job	2026-01-08T18:48:58.6172093Z Complete job name: Test (Rust on windows-latest)
+Test (Rust on windows-latest)	Run actions/checkout@v4	﻿2026-01-08T18:48:58.7664481Z ##[group]Run actions/checkout@v4
+Test (Rust on windows-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.7665910Z with:
+Test (Rust on windows-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.7666833Z   repository: link-foundation/lino-objects-codec
+Test (Rust on windows-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.7668390Z   token: ***
+Test (Rust on windows-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.7669175Z   ssh-strict: true
+Test (Rust on windows-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.7669995Z   ssh-user: git
+Test (Rust on windows-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.7670864Z   persist-credentials: true
+Test (Rust on windows-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.7671798Z   clean: true
+Test (Rust on windows-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.7672649Z   sparse-checkout-cone-mode: true
+Test (Rust on windows-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.7673663Z   fetch-depth: 1
+Test (Rust on windows-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.7674477Z   fetch-tags: false
+Test (Rust on windows-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.7675322Z   show-progress: true
+Test (Rust on windows-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.7676088Z   lfs: false
+Test (Rust on windows-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.7676698Z   submodules: false
+Test (Rust on windows-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.7677387Z   set-safe-directory: true
+Test (Rust on windows-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.7678320Z env:
+Test (Rust on windows-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.7678938Z   CARGO_TERM_COLOR: always
+Test (Rust on windows-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.7679757Z   RUSTFLAGS: -Dwarnings
+Test (Rust on windows-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.7680456Z ##[endgroup]
+Test (Rust on windows-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.9409041Z Syncing repository: link-foundation/lino-objects-codec
+Test (Rust on windows-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.9412233Z ##[group]Getting Git version info
+Test (Rust on windows-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.9413395Z Working directory is 'D:\a\lino-objects-codec\lino-objects-codec'
+Test (Rust on windows-latest)	Run actions/checkout@v4	2026-01-08T18:48:59.0570149Z [command]"C:\Program Files\Git\bin\git.exe" version
+Test (Rust on windows-latest)	Run actions/checkout@v4	2026-01-08T18:48:59.4457331Z git version 2.52.0.windows.1
+Test (Rust on windows-latest)	Run actions/checkout@v4	2026-01-08T18:48:59.4517883Z ##[endgroup]
+Test (Rust on windows-latest)	Run actions/checkout@v4	2026-01-08T18:48:59.4539804Z Temporarily overriding HOME='D:\a\_temp\57ee65e7-f6e0-45c6-bf26-392445606a7c' before making global git config changes
+Test (Rust on windows-latest)	Run actions/checkout@v4	2026-01-08T18:48:59.4542703Z Adding repository directory to the temporary git global config as a safe directory
+Test (Rust on windows-latest)	Run actions/checkout@v4	2026-01-08T18:48:59.4552561Z [command]"C:\Program Files\Git\bin\git.exe" config --global --add safe.directory D:\a\lino-objects-codec\lino-objects-codec
+Test (Rust on windows-latest)	Run actions/checkout@v4	2026-01-08T18:48:59.5146877Z Deleting the contents of 'D:\a\lino-objects-codec\lino-objects-codec'
+Test (Rust on windows-latest)	Run actions/checkout@v4	2026-01-08T18:48:59.5155124Z ##[group]Initializing the repository
+Test (Rust on windows-latest)	Run actions/checkout@v4	2026-01-08T18:48:59.5165434Z [command]"C:\Program Files\Git\bin\git.exe" init D:\a\lino-objects-codec\lino-objects-codec
+Test (Rust on windows-latest)	Run actions/checkout@v4	2026-01-08T18:48:59.6274732Z Initialized empty Git repository in D:/a/lino-objects-codec/lino-objects-codec/.git/
+Test (Rust on windows-latest)	Run actions/checkout@v4	2026-01-08T18:48:59.6326019Z [command]"C:\Program Files\Git\bin\git.exe" remote add origin https://github.com/link-foundation/lino-objects-codec
+Test (Rust on windows-latest)	Run actions/checkout@v4	2026-01-08T18:48:59.6997540Z ##[endgroup]
+Test (Rust on windows-latest)	Run actions/checkout@v4	2026-01-08T18:48:59.6999091Z ##[group]Disabling automatic garbage collection
+Test (Rust on windows-latest)	Run actions/checkout@v4	2026-01-08T18:48:59.7006997Z [command]"C:\Program Files\Git\bin\git.exe" config --local gc.auto 0
+Test (Rust on windows-latest)	Run actions/checkout@v4	2026-01-08T18:48:59.7300982Z ##[endgroup]
+Test (Rust on windows-latest)	Run actions/checkout@v4	2026-01-08T18:48:59.7302185Z ##[group]Setting up auth
+Test (Rust on windows-latest)	Run actions/checkout@v4	2026-01-08T18:48:59.7320855Z [command]"C:\Program Files\Git\bin\git.exe" config --local --name-only --get-regexp core\.sshCommand
+Test (Rust on windows-latest)	Run actions/checkout@v4	2026-01-08T18:48:59.7626287Z [command]"C:\Program Files\Git\bin\git.exe" submodule foreach --recursive "sh -c \"git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :\""
+Test (Rust on windows-latest)	Run actions/checkout@v4	2026-01-08T18:49:01.2396946Z [command]"C:\Program Files\Git\bin\git.exe" config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Test (Rust on windows-latest)	Run actions/checkout@v4	2026-01-08T18:49:01.2724230Z [command]"C:\Program Files\Git\bin\git.exe" submodule foreach --recursive "sh -c \"git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :\""
+Test (Rust on windows-latest)	Run actions/checkout@v4	2026-01-08T18:49:01.8056646Z [command]"C:\Program Files\Git\bin\git.exe" config --local --name-only --get-regexp ^includeIf\.gitdir:
+Test (Rust on windows-latest)	Run actions/checkout@v4	2026-01-08T18:49:01.8364669Z [command]"C:\Program Files\Git\bin\git.exe" submodule foreach --recursive "git config --local --show-origin --name-only --get-regexp remote.origin.url"
+Test (Rust on windows-latest)	Run actions/checkout@v4	2026-01-08T18:49:02.4082270Z [command]"C:\Program Files\Git\bin\git.exe" config --local http.https://github.com/.extraheader "AUTHORIZATION: basic ***"
+Test (Rust on windows-latest)	Run actions/checkout@v4	2026-01-08T18:49:02.4390475Z ##[endgroup]
+Test (Rust on windows-latest)	Run actions/checkout@v4	2026-01-08T18:49:02.4391294Z ##[group]Fetching the repository
+Test (Rust on windows-latest)	Run actions/checkout@v4	2026-01-08T18:49:02.4406040Z [command]"C:\Program Files\Git\bin\git.exe" -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +c79c77d68a90cadbd439c9613a7050501095c92d:refs/remotes/origin/main
+Test (Rust on windows-latest)	Run actions/checkout@v4	2026-01-08T18:49:03.6225840Z From https://github.com/link-foundation/lino-objects-codec
+Test (Rust on windows-latest)	Run actions/checkout@v4	2026-01-08T18:49:03.6226809Z  * [new ref]         c79c77d68a90cadbd439c9613a7050501095c92d -> origin/main
+Test (Rust on windows-latest)	Run actions/checkout@v4	2026-01-08T18:49:03.6501238Z ##[endgroup]
+Test (Rust on windows-latest)	Run actions/checkout@v4	2026-01-08T18:49:03.6501949Z ##[group]Determining the checkout info
+Test (Rust on windows-latest)	Run actions/checkout@v4	2026-01-08T18:49:03.6504505Z ##[endgroup]
+Test (Rust on windows-latest)	Run actions/checkout@v4	2026-01-08T18:49:03.6520584Z [command]"C:\Program Files\Git\bin\git.exe" sparse-checkout disable
+Test (Rust on windows-latest)	Run actions/checkout@v4	2026-01-08T18:49:03.7002488Z [command]"C:\Program Files\Git\bin\git.exe" config --local --unset-all extensions.worktreeConfig
+Test (Rust on windows-latest)	Run actions/checkout@v4	2026-01-08T18:49:03.7369214Z ##[group]Checking out the ref
+Test (Rust on windows-latest)	Run actions/checkout@v4	2026-01-08T18:49:03.7380962Z [command]"C:\Program Files\Git\bin\git.exe" checkout --progress --force -B main refs/remotes/origin/main
+Test (Rust on windows-latest)	Run actions/checkout@v4	2026-01-08T18:49:03.8472744Z branch 'main' set up to track 'origin/main'.
+Test (Rust on windows-latest)	Run actions/checkout@v4	2026-01-08T18:49:03.8482289Z Switched to a new branch 'main'
+Test (Rust on windows-latest)	Run actions/checkout@v4	2026-01-08T18:49:03.8522222Z ##[endgroup]
+Test (Rust on windows-latest)	Run actions/checkout@v4	2026-01-08T18:49:03.8899991Z [command]"C:\Program Files\Git\bin\git.exe" log -1 --format=%H
+Test (Rust on windows-latest)	Run actions/checkout@v4	2026-01-08T18:49:03.9177097Z c79c77d68a90cadbd439c9613a7050501095c92d
+Test (Rust on windows-latest)	Set up Rust	﻿2026-01-08T18:49:03.9688476Z ##[group]Run dtolnay/rust-toolchain@stable
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:03.9689567Z with:
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:03.9689737Z   toolchain: stable
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:03.9689910Z env:
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:03.9690071Z   CARGO_TERM_COLOR: always
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:03.9690281Z   RUSTFLAGS: -Dwarnings
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:03.9690459Z ##[endgroup]
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:03.9921164Z ##[group]Run : parse toolchain version
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:03.9921615Z [36;1m: parse toolchain version[0m
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:03.9921869Z [36;1mif [[ -z $toolchain ]]; then[0m
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:03.9922384Z [36;1m  # GitHub does not enforce `required: true` inputs itself. https://github.com/actions/runner/issues/1070[0m
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:03.9922920Z [36;1m  echo "'toolchain' is a required input" >&2[0m
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:03.9923192Z [36;1m  exit 1[0m
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:03.9923490Z [36;1melif [[ $toolchain =~ ^stable' '[0-9]+' '(year|month|week|day)s?' 'ago$ ]]; then[0m
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:03.9923887Z [36;1m  if [[ Windows == macOS ]]; then[0m
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:03.9924450Z [36;1m    echo "toolchain=1.$((($(date -v-$(sed 's/stable \([0-9]*\) \(.\).*/\1\2/' <<< $toolchain) +%s)/60/60/24-16569)/7/6))" >> $GITHUB_OUTPUT[0m
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:03.9924946Z [36;1m  else[0m
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:03.9925316Z [36;1m    echo "toolchain=1.$((($(date --date "${toolchain#stable }" +%s)/60/60/24-16569)/7/6))" >> $GITHUB_OUTPUT[0m
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:03.9925735Z [36;1m  fi[0m
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:03.9925994Z [36;1melif [[ $toolchain =~ ^stable' 'minus' '[0-9]+' 'releases?$ ]]; then[0m
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:03.9926483Z [36;1m  echo "toolchain=1.$((($(date +%s)/60/60/24-16569)/7/6-${toolchain//[^0-9]/}))" >> $GITHUB_OUTPUT[0m
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:03.9926910Z [36;1melif [[ $toolchain =~ ^1\.[0-9]+$ ]]; then[0m
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:03.9927394Z [36;1m  echo "toolchain=1.$((i=${toolchain#1.}, c=($(date +%s)/60/60/24-16569)/7/6, i+9*i*(10*i<=c)+90*i*(100*i<=c)))" >> $GITHUB_OUTPUT[0m
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:03.9927851Z [36;1melse[0m
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:03.9928063Z [36;1m  echo "toolchain=$toolchain" >> $GITHUB_OUTPUT[0m
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:03.9928330Z [36;1mfi[0m
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:03.9946986Z shell: C:\Program Files\Git\bin\bash.EXE --noprofile --norc -e -o pipefail {0}
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:03.9947398Z env:
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:03.9947571Z   CARGO_TERM_COLOR: always
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:03.9947774Z   RUSTFLAGS: -Dwarnings
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:03.9947968Z   toolchain: stable
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:03.9948136Z ##[endgroup]
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:04.1846124Z ##[group]Run : construct rustup command line
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:04.1846473Z [36;1m: construct rustup command line[0m
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:04.1846892Z [36;1mecho "targets=$(for t in ${targets//,/ }; do echo -n ' --target' $t; done)" >> $GITHUB_OUTPUT[0m
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:04.1847480Z [36;1mecho "components=$(for c in ${components//,/ }; do echo -n ' --component' $c; done)" >> $GITHUB_OUTPUT[0m
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:04.1847931Z [36;1mecho "downgrade=" >> $GITHUB_OUTPUT[0m
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:04.1863002Z shell: C:\Program Files\Git\bin\bash.EXE --noprofile --norc -e -o pipefail {0}
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:04.1863422Z env:
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:04.1863590Z   CARGO_TERM_COLOR: always
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:04.1863783Z   RUSTFLAGS: -Dwarnings
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:04.1863973Z   targets: 
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:04.1864116Z   components: 
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:04.1864275Z ##[endgroup]
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:04.2637697Z ##[group]Run : set $CARGO_HOME
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:04.2638218Z [36;1m: set $CARGO_HOME[0m
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:04.2638532Z [36;1mecho CARGO_HOME=${CARGO_HOME:-"$USERPROFILE\.cargo"} >> $GITHUB_ENV[0m
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:04.2651937Z shell: C:\Program Files\Git\bin\bash.EXE --noprofile --norc -e -o pipefail {0}
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:04.2652316Z env:
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:04.2652483Z   CARGO_TERM_COLOR: always
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:04.2652679Z   RUSTFLAGS: -Dwarnings
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:04.2652866Z ##[endgroup]
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:04.3467657Z ##[group]Run : install rustup if needed on windows
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:04.3468026Z [36;1m: install rustup if needed on windows[0m
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:04.3468309Z [36;1mif ! command -v rustup &>/dev/null; then[0m
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:04.3471258Z [36;1m  curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused --location --silent --show-error --fail https://win.rustup.rs/x86_64 --output 'D:\a\_temp\rustup-init.exe'[0m
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:04.3472095Z [36;1m  'D:\a\_temp\rustup-init.exe' --default-toolchain none --no-modify-path -y[0m
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:04.3472492Z [36;1m  echo "$CARGO_HOME\bin" >> $GITHUB_PATH[0m
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:04.3473153Z [36;1mfi[0m
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:04.3486188Z shell: C:\Program Files\Git\bin\bash.EXE --noprofile --norc -e -o pipefail {0}
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:04.3486563Z env:
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:04.3486724Z   CARGO_TERM_COLOR: always
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:04.3486929Z   RUSTFLAGS: -Dwarnings
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:04.3487140Z   CARGO_HOME: C:\Users\runneradmin\.cargo
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:04.3487369Z ##[endgroup]
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:04.4122242Z ##[group]Run rustup toolchain install stable --profile minimal --no-self-update
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:04.4122789Z [36;1mrustup toolchain install stable --profile minimal --no-self-update[0m
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:04.4136719Z shell: C:\Program Files\Git\bin\bash.EXE --noprofile --norc -e -o pipefail {0}
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:04.4137114Z env:
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:04.4137280Z   CARGO_TERM_COLOR: always
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:04.4137485Z   RUSTFLAGS: -Dwarnings
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:04.4137689Z   CARGO_HOME: C:\Users\runneradmin\.cargo
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:04.4137937Z   RUSTUP_PERMIT_COPY_RENAME: 1
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:04.4138136Z ##[endgroup]
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:07.6090495Z info: syncing channel updates for 'stable-x86_64-pc-windows-msvc'
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:08.0209831Z 
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:08.0416145Z   stable-x86_64-pc-windows-msvc unchanged - rustc 1.92.0 (ded5c06cf 2025-12-08)
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:08.0417225Z 
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:08.0629992Z ##[group]Run rustup default stable
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:08.0630260Z [36;1mrustup default stable[0m
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:08.0644359Z shell: C:\Program Files\Git\bin\bash.EXE --noprofile --norc -e -o pipefail {0}
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:08.0644729Z env:
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:08.0644913Z   CARGO_TERM_COLOR: always
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:08.0645119Z   RUSTFLAGS: -Dwarnings
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:08.0645324Z   CARGO_HOME: C:\Users\runneradmin\.cargo
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:08.0645558Z ##[endgroup]
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:08.1363548Z info: using existing install for 'stable-x86_64-pc-windows-msvc'
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:08.1894639Z info: default toolchain set to 'stable-x86_64-pc-windows-msvc'
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:08.1895154Z 
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:08.2097739Z   stable-x86_64-pc-windows-msvc unchanged - rustc 1.92.0 (ded5c06cf 2025-12-08)
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:08.2098113Z 
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:08.2294520Z ##[group]Run : create cachekey
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:08.2294774Z [36;1m: create cachekey[0m
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:08.2295236Z [36;1mDATE=$(rustc +stable --version --verbose | sed -ne 's/^commit-date: \(20[0-9][0-9]\)-\([01][0-9]\)-\([0-3][0-9]\)$/\1\2\3/p')[0m
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:08.2295845Z [36;1mHASH=$(rustc +stable --version --verbose | sed -ne 's/^commit-hash: //p')[0m
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:08.2296447Z [36;1mecho "cachekey=$(echo $DATE$HASH | head -c12)" >> $GITHUB_OUTPUT[0m
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:08.2309212Z shell: C:\Program Files\Git\bin\bash.EXE --noprofile --norc -e -o pipefail {0}
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:08.2309583Z env:
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:08.2309739Z   CARGO_TERM_COLOR: always
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:08.2309941Z   RUSTFLAGS: -Dwarnings
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:08.2310149Z   CARGO_HOME: C:\Users\runneradmin\.cargo
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:08.2310373Z ##[endgroup]
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.0934708Z ##[group]Run : disable incremental compilation
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.0935055Z [36;1m: disable incremental compilation[0m
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.0935335Z [36;1mif [ -z "${CARGO_INCREMENTAL+set}" ]; then[0m
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.0935628Z [36;1m  echo CARGO_INCREMENTAL=0 >> $GITHUB_ENV[0m
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.0935865Z [36;1mfi[0m
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.0948312Z shell: C:\Program Files\Git\bin\bash.EXE --noprofile --norc -e -o pipefail {0}
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.0948692Z env:
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.0948848Z   CARGO_TERM_COLOR: always
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.0949737Z   RUSTFLAGS: -Dwarnings
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.0950085Z   CARGO_HOME: C:\Users\runneradmin\.cargo
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.0950320Z ##[endgroup]
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.1461652Z ##[group]Run : enable colors in Cargo output
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.1461975Z [36;1m: enable colors in Cargo output[0m
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.1462244Z [36;1mif [ -z "${CARGO_TERM_COLOR+set}" ]; then[0m
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.1462565Z [36;1m  echo CARGO_TERM_COLOR=always >> $GITHUB_ENV[0m
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.1462822Z [36;1mfi[0m
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.1475900Z shell: C:\Program Files\Git\bin\bash.EXE --noprofile --norc -e -o pipefail {0}
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.1476273Z env:
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.1476434Z   CARGO_TERM_COLOR: always
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.1476649Z   RUSTFLAGS: -Dwarnings
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.1476866Z   CARGO_HOME: C:\Users\runneradmin\.cargo
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.1477116Z   CARGO_INCREMENTAL: 0
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.1477290Z ##[endgroup]
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.2022013Z ##[group]Run : enable Cargo sparse registry
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.2022592Z [36;1m: enable Cargo sparse registry[0m
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.2023933Z [36;1m# implemented in 1.66, stabilized in 1.68, made default in 1.70[0m
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.2024784Z [36;1mif [ -z "${CARGO_REGISTRIES_CRATES_IO_PROTOCOL+set}" -o -f "D:\a\_temp"/.implicit_cargo_registries_crates_io_protocol ]; then[0m
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.2025583Z [36;1m  if rustc +stable --version --verbose | grep -q '^release: 1\.6[89]\.'; then[0m
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.2026177Z [36;1m    touch "D:\a\_temp"/.implicit_cargo_registries_crates_io_protocol || true[0m
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.2026743Z [36;1m    echo CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse >> $GITHUB_ENV[0m
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.2027429Z [36;1m  elif rustc +stable --version --verbose | grep -q '^release: 1\.6[67]\.'; then[0m
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.2046461Z [36;1m    touch "D:\a\_temp"/.implicit_cargo_registries_crates_io_protocol || true[0m
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.2047282Z [36;1m    echo CARGO_REGISTRIES_CRATES_IO_PROTOCOL=git >> $GITHUB_ENV[0m
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.2047829Z [36;1m  fi[0m
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.2048110Z [36;1mfi[0m
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.2065596Z shell: C:\Program Files\Git\bin\bash.EXE --noprofile --norc -e -o pipefail {0}
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.2065975Z env:
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.2066140Z   CARGO_TERM_COLOR: always
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.2066335Z   RUSTFLAGS: -Dwarnings
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.2066545Z   CARGO_HOME: C:\Users\runneradmin\.cargo
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.2066780Z   CARGO_INCREMENTAL: 0
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.2066960Z ##[endgroup]
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.4104724Z ##[group]Run : work around spurious network errors in curl 8.0
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.4105130Z [36;1m: work around spurious network errors in curl 8.0[0m
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.4105661Z [36;1m# https://rust-lang.zulipchat.com/#narrow/stream/246057-t-cargo/topic/timeout.20investigation[0m
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.4106248Z [36;1mif rustc +stable --version --verbose | grep -q '^release: 1\.7[01]\.'; then[0m
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.4106673Z [36;1m  echo CARGO_HTTP_MULTIPLEXING=false >> $GITHUB_ENV[0m
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.4106976Z [36;1mfi[0m
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.4120580Z shell: C:\Program Files\Git\bin\bash.EXE --noprofile --norc -e -o pipefail {0}
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.4120962Z env:
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.4121114Z   CARGO_TERM_COLOR: always
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.4121320Z   RUSTFLAGS: -Dwarnings
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.4121522Z   CARGO_HOME: C:\Users\runneradmin\.cargo
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.4121760Z   CARGO_INCREMENTAL: 0
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.4121931Z ##[endgroup]
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.5535131Z ##[group]Run rustc +stable --version --verbose
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.5535458Z [36;1mrustc +stable --version --verbose[0m
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.5548911Z shell: C:\Program Files\Git\bin\bash.EXE --noprofile --norc -e -o pipefail {0}
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.5549295Z env:
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.5549448Z   CARGO_TERM_COLOR: always
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.5549649Z   RUSTFLAGS: -Dwarnings
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.5549856Z   CARGO_HOME: C:\Users\runneradmin\.cargo
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.5550087Z   CARGO_INCREMENTAL: 0
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.5550441Z ##[endgroup]
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.6411879Z rustc 1.92.0 (ded5c06cf 2025-12-08)
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.6413021Z binary: rustc
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.6413525Z commit-hash: ded5c06cf21d2b93bffd5d884aa6e96934ee4234
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.6414495Z commit-date: 2025-12-08
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.6415247Z host: x86_64-pc-windows-msvc
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.6415869Z release: 1.92.0
+Test (Rust on windows-latest)	Set up Rust	2026-01-08T18:49:09.6417163Z LLVM version: 21.1.3
+Test (Rust on windows-latest)	Cache cargo dependencies	﻿2026-01-08T18:49:09.7811447Z ##[group]Run actions/cache@v4
+Test (Rust on windows-latest)	Cache cargo dependencies	2026-01-08T18:49:09.7811781Z with:
+Test (Rust on windows-latest)	Cache cargo dependencies	2026-01-08T18:49:09.7812157Z   path: ~/.cargo/bin/
+Test (Rust on windows-latest)	Cache cargo dependencies	~/.cargo/registry/index/
+Test (Rust on windows-latest)	Cache cargo dependencies	~/.cargo/registry/cache/
+Test (Rust on windows-latest)	Cache cargo dependencies	~/.cargo/git/db/
+Test (Rust on windows-latest)	Cache cargo dependencies	rust/target/
+Test (Rust on windows-latest)	Cache cargo dependencies	
+Test (Rust on windows-latest)	Cache cargo dependencies	2026-01-08T18:49:09.7812778Z   key: Windows-cargo-06d79b45cf01dd89665cb7e81015e9ed0cc5bbb8f1a0c5dda8ea1287080b6af5
+Test (Rust on windows-latest)	Cache cargo dependencies	2026-01-08T18:49:09.7813210Z   enableCrossOsArchive: false
+Test (Rust on windows-latest)	Cache cargo dependencies	2026-01-08T18:49:09.7813468Z   fail-on-cache-miss: false
+Test (Rust on windows-latest)	Cache cargo dependencies	2026-01-08T18:49:09.7813667Z   lookup-only: false
+Test (Rust on windows-latest)	Cache cargo dependencies	2026-01-08T18:49:09.7813844Z   save-always: false
+Test (Rust on windows-latest)	Cache cargo dependencies	2026-01-08T18:49:09.7813996Z env:
+Test (Rust on windows-latest)	Cache cargo dependencies	2026-01-08T18:49:09.7814168Z   CARGO_TERM_COLOR: always
+Test (Rust on windows-latest)	Cache cargo dependencies	2026-01-08T18:49:09.7814363Z   RUSTFLAGS: -Dwarnings
+Test (Rust on windows-latest)	Cache cargo dependencies	2026-01-08T18:49:09.7814561Z   CARGO_HOME: C:\Users\runneradmin\.cargo
+Test (Rust on windows-latest)	Cache cargo dependencies	2026-01-08T18:49:09.7814795Z   CARGO_INCREMENTAL: 0
+Test (Rust on windows-latest)	Cache cargo dependencies	2026-01-08T18:49:09.7814961Z ##[endgroup]
+Test (Rust on windows-latest)	Cache cargo dependencies	2026-01-08T18:49:10.3997757Z Cache hit for: Windows-cargo-06d79b45cf01dd89665cb7e81015e9ed0cc5bbb8f1a0c5dda8ea1287080b6af5
+Test (Rust on windows-latest)	Cache cargo dependencies	2026-01-08T18:49:11.6636056Z Received 50331648 of 80574105 (62.5%), 47.8 MBs/sec
+Test (Rust on windows-latest)	Cache cargo dependencies	2026-01-08T18:49:12.0912424Z Received 80574105 of 80574105 (100.0%), 53.7 MBs/sec
+Test (Rust on windows-latest)	Cache cargo dependencies	2026-01-08T18:49:12.0916158Z Cache Size: ~77 MB (80574105 B)
+Test (Rust on windows-latest)	Cache cargo dependencies	2026-01-08T18:49:12.0994850Z [command]"C:\Program Files\Git\usr\bin\tar.exe" -xf D:/a/_temp/582af113-c8e4-4e2e-a5a6-580782962dba/cache.tzst -P -C D:/a/lino-objects-codec/lino-objects-codec --force-local --use-compress-program "zstd -d"
+Test (Rust on windows-latest)	Cache cargo dependencies	2026-01-08T18:49:12.7013951Z Cache restored successfully
+Test (Rust on windows-latest)	Cache cargo dependencies	2026-01-08T18:49:12.7208358Z Cache restored from key: Windows-cargo-06d79b45cf01dd89665cb7e81015e9ed0cc5bbb8f1a0c5dda8ea1287080b6af5
+Test (Rust on windows-latest)	Run tests	﻿2026-01-08T18:49:12.7494503Z ##[group]Run cargo test --verbose
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:12.7494895Z [36;1mcargo test --verbose[0m
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:12.8249509Z shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:12.8249927Z env:
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:12.8250123Z   CARGO_TERM_COLOR: always
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:12.8250355Z   RUSTFLAGS: -Dwarnings
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:12.8250590Z   CARGO_HOME: C:\Users\runneradmin\.cargo
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:12.8250864Z   CARGO_INCREMENTAL: 0
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:12.8251065Z ##[endgroup]
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:21.7271895Z [1m[92m   Compiling[0m memchr v2.7.6
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:21.7272952Z [1m[92m   Compiling[0m base64 v0.22.1
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:21.7292592Z [1m[92m     Running[0m `C:\Users\runneradmin\.rustup\toolchains\stable-x86_64-pc-windows-msvc\bin\rustc.exe --crate-name memchr --edition=2021 C:\Users\runneradmin\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\memchr-2.7.6\src\lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debuginfo=2 --cfg "feature=\"alloc\"" --cfg "feature=\"std\"" --check-cfg cfg(docsrs,test) --check-cfg "cfg(feature, values(\"alloc\", \"core\", \"default\", \"libc\", \"logging\", \"rustc-dep-of-std\", \"std\", \"use_std\"))" -C metadata=ccee7b15a985d2ca -C extra-filename=-d650d92ef9b456b3 --out-dir D:\a\lino-objects-codec\lino-objects-codec\rust\target\debug\deps -L dependency=D:\a\lino-objects-codec\lino-objects-codec\rust\target\debug\deps --cap-lints allow -Dwarnings`
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:21.7299461Z [1m[92m     Running[0m `C:\Users\runneradmin\.rustup\toolchains\stable-x86_64-pc-windows-msvc\bin\rustc.exe --crate-name base64 --edition=2018 C:\Users\runneradmin\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\base64-0.22.1\src\lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debuginfo=2 --cfg "feature=\"alloc\"" --cfg "feature=\"default\"" --cfg "feature=\"std\"" --check-cfg cfg(docsrs,test) --check-cfg "cfg(feature, values(\"alloc\", \"default\", \"std\"))" -C metadata=123e056a7310805b -C extra-filename=-94827819961b392a --out-dir D:\a\lino-objects-codec\lino-objects-codec\rust\target\debug\deps -L dependency=D:\a\lino-objects-codec\lino-objects-codec\rust\target\debug\deps --cap-lints allow -Dwarnings`
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:28.1122182Z [1m[92m   Compiling[0m nom v8.0.0
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:28.1129990Z [1m[92m     Running[0m `C:\Users\runneradmin\.rustup\toolchains\stable-x86_64-pc-windows-msvc\bin\rustc.exe --crate-name nom --edition=2021 C:\Users\runneradmin\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\nom-8.0.0\src\lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debuginfo=2 --cfg "feature=\"alloc\"" --cfg "feature=\"default\"" --cfg "feature=\"std\"" --check-cfg cfg(docsrs,test) --check-cfg "cfg(feature, values(\"alloc\", \"default\", \"docsrs\", \"std\"))" -C metadata=3ed40abe2f33b3c4 -C extra-filename=-74f5f692ddf8b02b --out-dir D:\a\lino-objects-codec\lino-objects-codec\rust\target\debug\deps -L dependency=D:\a\lino-objects-codec\lino-objects-codec\rust\target\debug\deps --extern memchr=D:\a\lino-objects-codec\lino-objects-codec\rust\target\debug\deps\libmemchr-d650d92ef9b456b3.rmeta --cap-lints allow -Dwarnings`
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:31.6257817Z [1m[92m   Compiling[0m links-notation v0.13.0
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:31.6266773Z [1m[92m     Running[0m `C:\Users\runneradmin\.rustup\toolchains\stable-x86_64-pc-windows-msvc\bin\rustc.exe --crate-name links_notation --edition=2021 C:\Users\runneradmin\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\links-notation-0.13.0\src\lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debuginfo=2 --check-cfg cfg(docsrs,test) --check-cfg "cfg(feature, values())" -C metadata=ba27978c915f6c40 -C extra-filename=-255cb93a5f36e1ce --out-dir D:\a\lino-objects-codec\lino-objects-codec\rust\target\debug\deps -L dependency=D:\a\lino-objects-codec\lino-objects-codec\rust\target\debug\deps --extern nom=D:\a\lino-objects-codec\lino-objects-codec\rust\target\debug\deps\libnom-74f5f692ddf8b02b.rmeta --cap-lints allow -Dwarnings`
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:32.1258531Z [1m[92m   Compiling[0m lino-objects-codec v0.2.0 (D:\a\lino-objects-codec\lino-objects-codec\rust)
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:32.1279741Z [1m[92m     Running[0m `C:\Users\runneradmin\.rustup\toolchains\stable-x86_64-pc-windows-msvc\bin\rustc.exe --crate-name lino_objects_codec --edition=2021 src\lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debuginfo=2 --warn=clippy::pedantic --warn=clippy::nursery --warn=clippy::all --allow=clippy::use_self --allow=clippy::unused_self --allow=clippy::unreadable_literal --allow=clippy::uninlined_format_args --allow=clippy::too_many_lines --allow=clippy::similar_names --allow=clippy::redundant_closure_for_method_calls --allow=clippy::redundant_clone --allow=clippy::option_if_let_else --allow=clippy::must_use_candidate --allow=clippy::module_name_repetitions --allow=clippy::missing_panics_doc --allow=clippy::missing_errors_doc --allow=clippy::missing_const_for_fn --allow=clippy::inefficient_to_string --allow=clippy::ignored_unit_patterns --allow=clippy::if_not_else --allow=clippy::doc_markdown --allow=clippy::derive_partial_eq_without_eq --allow=clippy::cast_precision_loss --allow=clippy::cast_lossless --allow=clippy::assigning_clones --allow=clippy::approx_constant --check-cfg cfg(docsrs,test) --check-cfg "cfg(feature, values())" -C metadata=891887729fbb226f -C extra-filename=-bf4ca32a6392e72b --out-dir D:\a\lino-objects-codec\lino-objects-codec\rust\target\debug\deps -L dependency=D:\a\lino-objects-codec\lino-objects-codec\rust\target\debug\deps --extern base64=D:\a\lino-objects-codec\lino-objects-codec\rust\target\debug\deps\libbase64-94827819961b392a.rmeta --extern links_notation=D:\a\lino-objects-codec\lino-objects-codec\rust\target\debug\deps\liblinks_notation-255cb93a5f36e1ce.rmeta -Dwarnings`
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:32.5628646Z [1m[92m     Running[0m `C:\Users\runneradmin\.rustup\toolchains\stable-x86_64-pc-windows-msvc\bin\rustc.exe --crate-name lino_objects_codec --edition=2021 src\lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --emit=dep-info,link -C embed-bitcode=no -C debuginfo=2 --warn=clippy::pedantic --warn=clippy::nursery --warn=clippy::all --allow=clippy::use_self --allow=clippy::unused_self --allow=clippy::unreadable_literal --allow=clippy::uninlined_format_args --allow=clippy::too_many_lines --allow=clippy::similar_names --allow=clippy::redundant_closure_for_method_calls --allow=clippy::redundant_clone --allow=clippy::option_if_let_else --allow=clippy::must_use_candidate --allow=clippy::module_name_repetitions --allow=clippy::missing_panics_doc --allow=clippy::missing_errors_doc --allow=clippy::missing_const_for_fn --allow=clippy::inefficient_to_string --allow=clippy::ignored_unit_patterns --allow=clippy::if_not_else --allow=clippy::doc_markdown --allow=clippy::derive_partial_eq_without_eq --allow=clippy::cast_precision_loss --allow=clippy::cast_lossless --allow=clippy::assigning_clones --allow=clippy::approx_constant --test --check-cfg cfg(docsrs,test) --check-cfg "cfg(feature, values())" -C metadata=02815b31b91ad292 -C extra-filename=-f0f710c7e5189fb2 --out-dir D:\a\lino-objects-codec\lino-objects-codec\rust\target\debug\deps -L dependency=D:\a\lino-objects-codec\lino-objects-codec\rust\target\debug\deps --extern base64=D:\a\lino-objects-codec\lino-objects-codec\rust\target\debug\deps\libbase64-94827819961b392a.rlib --extern links_notation=D:\a\lino-objects-codec\lino-objects-codec\rust\target\debug\deps\liblinks_notation-255cb93a5f36e1ce.rlib -Dwarnings`
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:32.9563492Z [1m[92m     Running[0m `C:\Users\runneradmin\.rustup\toolchains\stable-x86_64-pc-windows-msvc\bin\rustc.exe --crate-name basic_usage --edition=2021 examples\basic_usage.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --crate-type bin --emit=dep-info,link -C embed-bitcode=no -C debuginfo=2 --warn=clippy::pedantic --warn=clippy::nursery --warn=clippy::all --allow=clippy::use_self --allow=clippy::unused_self --allow=clippy::unreadable_literal --allow=clippy::uninlined_format_args --allow=clippy::too_many_lines --allow=clippy::similar_names --allow=clippy::redundant_closure_for_method_calls --allow=clippy::redundant_clone --allow=clippy::option_if_let_else --allow=clippy::must_use_candidate --allow=clippy::module_name_repetitions --allow=clippy::missing_panics_doc --allow=clippy::missing_errors_doc --allow=clippy::missing_const_for_fn --allow=clippy::inefficient_to_string --allow=clippy::ignored_unit_patterns --allow=clippy::if_not_else --allow=clippy::doc_markdown --allow=clippy::derive_partial_eq_without_eq --allow=clippy::cast_precision_loss --allow=clippy::cast_lossless --allow=clippy::assigning_clones --allow=clippy::approx_constant --check-cfg cfg(docsrs,test) --check-cfg "cfg(feature, values())" -C metadata=5aedbe7b951165a2 --out-dir D:\a\lino-objects-codec\lino-objects-codec\rust\target\debug\examples -L dependency=D:\a\lino-objects-codec\lino-objects-codec\rust\target\debug\deps --extern base64=D:\a\lino-objects-codec\lino-objects-codec\rust\target\debug\deps\libbase64-94827819961b392a.rlib --extern links_notation=D:\a\lino-objects-codec\lino-objects-codec\rust\target\debug\deps\liblinks_notation-255cb93a5f36e1ce.rlib --extern lino_objects_codec=D:\a\lino-objects-codec\lino-objects-codec\rust\target\debug\deps\liblino_objects_codec-bf4ca32a6392e72b.rlib -Dwarnings`
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:35.5779495Z [1m[92m    Finished[0m `test` profile [unoptimized + debuginfo] target(s) in 16.18s
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:35.6213587Z [1m[92m     Running[0m `D:\a\lino-objects-codec\lino-objects-codec\rust\target\debug\deps\lino_objects_codec-f0f710c7e5189fb2.exe`
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:35.6323435Z 
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:35.6324494Z running 32 tests
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:35.6331627Z test format_tests::test_escape_reference_string_with_double_quotes ... ok
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:35.6334975Z test format_tests::test_escape_reference_string_with_single_quotes ... ok
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:35.6336596Z test format_tests::test_escape_reference_string_with_spaces ... ok
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:35.6339911Z test format_tests::test_escape_reference_simple_string ... ok
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:35.6345922Z test format_tests::test_format_indented_ordered_basic ... ok
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:35.6348721Z test format_tests::test_format_indented_requires_id ... ok
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:35.6349866Z test format_tests::test_format_indented_value_with_quotes ... ok
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:35.6359376Z test format_tests::test_parse_indented_basic ... ok
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:35.6361023Z test format_tests::test_parse_indented_empty_lines_skipped ... ok
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:35.6362126Z test format_tests::test_parse_indented_requires_text ... ok
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:35.6366242Z test format_tests::test_parse_indented_with_quotes ... ok
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:35.6376836Z test format_tests::test_roundtrip_format_indented ... ok
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:35.6378232Z test format_tests::test_roundtrip_with_quotes ... ok
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:35.6379701Z test format_tests::test_unescape_reference_doubled_quotes ... ok
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:35.6387808Z test tests::test_float_special_values ... ok
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:35.6390087Z test tests::test_complex_structure ... ok
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:35.6392825Z test tests::test_dict_of_lists ... ok
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:35.6393923Z test tests::test_list_of_dicts ... ok
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:35.6398343Z test tests::test_nested_arrays ... ok
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:35.6399194Z test tests::test_nested_objects ... ok
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:35.6401683Z test tests::test_roundtrip_empty_array ... ok
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:35.6403237Z test tests::test_roundtrip_bool ... ok
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:35.6404036Z test tests::test_roundtrip_empty_object ... ok
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:35.6408688Z test tests::test_roundtrip_float ... ok
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:35.6409591Z test tests::test_roundtrip_null ... ok
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:35.6410095Z test tests::test_roundtrip_mixed_array ... ok
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:35.6415178Z test tests::test_roundtrip_int ... ok
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:35.6417116Z test tests::test_roundtrip_simple_array ... ok
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:35.6417845Z test tests::test_roundtrip_simple_object ... ok
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:35.6421460Z test tests::test_roundtrip_string ... ok
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:35.6423934Z test tests::test_string_with_quotes ... ok
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:35.6425931Z test tests::test_unicode_string ... ok
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:35.6426264Z 
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:35.6426666Z test result: ok. 32 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:35.6427269Z 
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:35.6443275Z [1m[92m   Doc-tests[0m lino_objects_codec
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:35.6510020Z [1m[92m     Running[0m `C:\Users\runneradmin\.rustup\toolchains\stable-x86_64-pc-windows-msvc\bin\rustdoc.exe --edition=2021 --crate-type lib --color always --crate-name lino_objects_codec --test src\lib.rs --test-run-directory D:\a\lino-objects-codec\lino-objects-codec\rust -L dependency=D:\a\lino-objects-codec\lino-objects-codec\rust\target\debug\deps -L dependency=D:\a\lino-objects-codec\lino-objects-codec\rust\target\debug\deps --warn=clippy::pedantic --warn=clippy::nursery --warn=clippy::all --allow=clippy::use_self --allow=clippy::unused_self --allow=clippy::unreadable_literal --allow=clippy::uninlined_format_args --allow=clippy::too_many_lines --allow=clippy::similar_names --allow=clippy::redundant_closure_for_method_calls --allow=clippy::redundant_clone --allow=clippy::option_if_let_else --allow=clippy::must_use_candidate --allow=clippy::module_name_repetitions --allow=clippy::missing_panics_doc --allow=clippy::missing_errors_doc --allow=clippy::missing_const_for_fn --allow=clippy::inefficient_to_string --allow=clippy::ignored_unit_patterns --allow=clippy::if_not_else --allow=clippy::doc_markdown --allow=clippy::derive_partial_eq_without_eq --allow=clippy::cast_precision_loss --allow=clippy::cast_lossless --allow=clippy::assigning_clones --allow=clippy::approx_constant --extern base64=D:\a\lino-objects-codec\lino-objects-codec\rust\target\debug\deps\libbase64-94827819961b392a.rlib --extern links_notation=D:\a\lino-objects-codec\lino-objects-codec\rust\target\debug\deps\liblinks_notation-255cb93a5f36e1ce.rlib --extern lino_objects_codec=D:\a\lino-objects-codec\lino-objects-codec\rust\target\debug\deps\liblino_objects_codec-bf4ca32a6392e72b.rlib -C embed-bitcode=no --check-cfg cfg(docsrs,test) --check-cfg "cfg(feature, values())" --error-format human`
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:36.5491001Z 
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:36.5491477Z running 5 tests
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:37.0170231Z test src\lib.rs - (line 19) ... ok
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:37.0240074Z test src\lib.rs - encode (line 858) ... ok
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:37.0425471Z test src\lib.rs - decode (line 887) ... ok
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:37.0580867Z test src\lib.rs - format::format_indented (line 1043) ... ok
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:37.2524447Z test src\lib.rs - format::parse_indented (line 1139) ... ok
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:37.2525000Z 
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:37.2529204Z test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.70s
+Test (Rust on windows-latest)	Run tests	2026-01-08T18:49:37.2529804Z 
+Test (Rust on windows-latest)	Run doc tests	﻿2026-01-08T18:49:37.7740561Z ##[group]Run cargo test --doc --verbose
+Test (Rust on windows-latest)	Run doc tests	2026-01-08T18:49:37.7740955Z [36;1mcargo test --doc --verbose[0m
+Test (Rust on windows-latest)	Run doc tests	2026-01-08T18:49:37.7800823Z shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"
+Test (Rust on windows-latest)	Run doc tests	2026-01-08T18:49:37.7801168Z env:
+Test (Rust on windows-latest)	Run doc tests	2026-01-08T18:49:37.7801329Z   CARGO_TERM_COLOR: always
+Test (Rust on windows-latest)	Run doc tests	2026-01-08T18:49:37.7801535Z   RUSTFLAGS: -Dwarnings
+Test (Rust on windows-latest)	Run doc tests	2026-01-08T18:49:37.7801754Z   CARGO_HOME: C:\Users\runneradmin\.cargo
+Test (Rust on windows-latest)	Run doc tests	2026-01-08T18:49:37.7801993Z   CARGO_INCREMENTAL: 0
+Test (Rust on windows-latest)	Run doc tests	2026-01-08T18:49:37.7802172Z ##[endgroup]
+Test (Rust on windows-latest)	Run doc tests	2026-01-08T18:49:38.1617470Z [1m[92m       Fresh[0m memchr v2.7.6
+Test (Rust on windows-latest)	Run doc tests	2026-01-08T18:49:38.1619163Z [1m[92m       Fresh[0m nom v8.0.0
+Test (Rust on windows-latest)	Run doc tests	2026-01-08T18:49:38.1620635Z [1m[92m       Fresh[0m base64 v0.22.1
+Test (Rust on windows-latest)	Run doc tests	2026-01-08T18:49:38.1622006Z [1m[92m       Fresh[0m links-notation v0.13.0
+Test (Rust on windows-latest)	Run doc tests	2026-01-08T18:49:38.1624496Z [1m[92m       Fresh[0m lino-objects-codec v0.2.0 (D:\a\lino-objects-codec\lino-objects-codec\rust)
+Test (Rust on windows-latest)	Run doc tests	2026-01-08T18:49:38.1625456Z [1m[92m    Finished[0m `test` profile [unoptimized + debuginfo] target(s) in 0.02s
+Test (Rust on windows-latest)	Run doc tests	2026-01-08T18:49:38.1629460Z [1m[92m   Doc-tests[0m lino_objects_codec
+Test (Rust on windows-latest)	Run doc tests	2026-01-08T18:49:38.1664227Z [1m[92m     Running[0m `C:\Users\runneradmin\.rustup\toolchains\stable-x86_64-pc-windows-msvc\bin\rustdoc.exe --edition=2021 --crate-type lib --color always --crate-name lino_objects_codec --test src\lib.rs --test-run-directory D:\a\lino-objects-codec\lino-objects-codec\rust -L dependency=D:\a\lino-objects-codec\lino-objects-codec\rust\target\debug\deps -L dependency=D:\a\lino-objects-codec\lino-objects-codec\rust\target\debug\deps --warn=clippy::pedantic --warn=clippy::nursery --warn=clippy::all --allow=clippy::use_self --allow=clippy::unused_self --allow=clippy::unreadable_literal --allow=clippy::uninlined_format_args --allow=clippy::too_many_lines --allow=clippy::similar_names --allow=clippy::redundant_closure_for_method_calls --allow=clippy::redundant_clone --allow=clippy::option_if_let_else --allow=clippy::must_use_candidate --allow=clippy::module_name_repetitions --allow=clippy::missing_panics_doc --allow=clippy::missing_errors_doc --allow=clippy::missing_const_for_fn --allow=clippy::inefficient_to_string --allow=clippy::ignored_unit_patterns --allow=clippy::if_not_else --allow=clippy::doc_markdown --allow=clippy::derive_partial_eq_without_eq --allow=clippy::cast_precision_loss --allow=clippy::cast_lossless --allow=clippy::assigning_clones --allow=clippy::approx_constant --extern base64=D:\a\lino-objects-codec\lino-objects-codec\rust\target\debug\deps\libbase64-94827819961b392a.rlib --extern links_notation=D:\a\lino-objects-codec\lino-objects-codec\rust\target\debug\deps\liblinks_notation-255cb93a5f36e1ce.rlib --extern lino_objects_codec=D:\a\lino-objects-codec\lino-objects-codec\rust\target\debug\deps\liblino_objects_codec-bf4ca32a6392e72b.rlib -C embed-bitcode=no --check-cfg cfg(docsrs,test) --check-cfg "cfg(feature, values())" --error-format human`
+Test (Rust on windows-latest)	Run doc tests	2026-01-08T18:49:38.2116483Z 
+Test (Rust on windows-latest)	Run doc tests	2026-01-08T18:49:38.2117025Z running 5 tests
+Test (Rust on windows-latest)	Run doc tests	2026-01-08T18:49:38.5955647Z test src\lib.rs - decode (line 887) ... ok
+Test (Rust on windows-latest)	Run doc tests	2026-01-08T18:49:38.5993360Z test src\lib.rs - format::format_indented (line 1043) ... ok
+Test (Rust on windows-latest)	Run doc tests	2026-01-08T18:49:38.6131096Z test src\lib.rs - (line 19) ... ok
+Test (Rust on windows-latest)	Run doc tests	2026-01-08T18:49:38.6338441Z test src\lib.rs - encode (line 858) ... ok
+Test (Rust on windows-latest)	Run doc tests	2026-01-08T18:49:38.8200044Z test src\lib.rs - format::parse_indented (line 1139) ... ok
+Test (Rust on windows-latest)	Run doc tests	2026-01-08T18:49:38.8200368Z 
+Test (Rust on windows-latest)	Run doc tests	2026-01-08T18:49:38.8200604Z test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.61s
+Test (Rust on windows-latest)	Run doc tests	2026-01-08T18:49:38.8200937Z 
+Test (Rust on windows-latest)	Run example	﻿2026-01-08T18:49:38.9783254Z ##[group]Run cargo run --example basic_usage
+Test (Rust on windows-latest)	Run example	2026-01-08T18:49:38.9783669Z [36;1mcargo run --example basic_usage[0m
+Test (Rust on windows-latest)	Run example	2026-01-08T18:49:38.9844914Z shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"
+Test (Rust on windows-latest)	Run example	2026-01-08T18:49:38.9845259Z env:
+Test (Rust on windows-latest)	Run example	2026-01-08T18:49:38.9845418Z   CARGO_TERM_COLOR: always
+Test (Rust on windows-latest)	Run example	2026-01-08T18:49:38.9845626Z   RUSTFLAGS: -Dwarnings
+Test (Rust on windows-latest)	Run example	2026-01-08T18:49:38.9845841Z   CARGO_HOME: C:\Users\runneradmin\.cargo
+Test (Rust on windows-latest)	Run example	2026-01-08T18:49:38.9846092Z   CARGO_INCREMENTAL: 0
+Test (Rust on windows-latest)	Run example	2026-01-08T18:49:38.9846275Z ##[endgroup]
+Test (Rust on windows-latest)	Run example	2026-01-08T18:49:39.3394806Z [1m[92m    Finished[0m `dev` profile [unoptimized + debuginfo] target(s) in 0.02s
+Test (Rust on windows-latest)	Run example	2026-01-08T18:49:39.3401053Z [1m[92m     Running[0m `target\debug\examples\basic_usage.exe`
+Test (Rust on windows-latest)	Run example	2026-01-08T18:49:39.3493543Z === Links Notation Objects Codec - Rust Example ===
+Test (Rust on windows-latest)	Run example	2026-01-08T18:49:39.3493989Z 
+Test (Rust on windows-latest)	Run example	2026-01-08T18:49:39.3494587Z 1. Basic Types:
+Test (Rust on windows-latest)	Run example	2026-01-08T18:49:39.3496930Z    Null: (null) -> decoded: Null
+Test (Rust on windows-latest)	Run example	2026-01-08T18:49:39.3497306Z    true: (bool true) -> decoded: Bool(true)
+Test (Rust on windows-latest)	Run example	2026-01-08T18:49:39.3498410Z    42: (int 42) -> decoded: Int(42)
+Test (Rust on windows-latest)	Run example	2026-01-08T18:49:39.3499403Z    3.14159: (float 3.14159) -> decoded: Float(3.14159)
+Test (Rust on windows-latest)	Run example	2026-01-08T18:49:39.3499933Z    Infinity: (float Infinity) -> decoded: Float(inf)
+Test (Rust on windows-latest)	Run example	2026-01-08T18:49:39.3501148Z    NaN: (float NaN) -> decoded is_nan: true
+Test (Rust on windows-latest)	Run example	2026-01-08T18:49:39.3502525Z    'Hello, World!': (str SGVsbG8sIFdvcmxkIQ==) -> decoded: String("Hello, World!")
+Test (Rust on windows-latest)	Run example	2026-01-08T18:49:39.3503682Z    Unicode: (str 5L2g5aW95LiW55WMIPCfjI0=) -> decoded: String("你好世界 🌍")
+Test (Rust on windows-latest)	Run example	2026-01-08T18:49:39.3504444Z 
+Test (Rust on windows-latest)	Run example	2026-01-08T18:49:39.3504539Z 2. Collections:
+Test (Rust on windows-latest)	Run example	2026-01-08T18:49:39.3505473Z    Array [1, 2, 3]: (array (int 1) (int 2) (int 3))
+Test (Rust on windows-latest)	Run example	2026-01-08T18:49:39.3506295Z    Decoded: Array([Int(1), Int(2), Int(3)])
+Test (Rust on windows-latest)	Run example	2026-01-08T18:49:39.3508114Z    Object {name, age, active}: (object ((str bmFtZQ==) (str QWxpY2U=)) ((str YWdl) (int 30)) ((str YWN0aXZl) (bool true)))
+Test (Rust on windows-latest)	Run example	2026-01-08T18:49:39.3509146Z    Decoded: Object([("name", String("Alice")), ("age", Int(30)), ("active", Bool(true))])
+Test (Rust on windows-latest)	Run example	2026-01-08T18:49:39.3509471Z 
+Test (Rust on windows-latest)	Run example	2026-01-08T18:49:39.3509554Z 3. Nested Structure:
+Test (Rust on windows-latest)	Run example	2026-01-08T18:49:39.3512543Z    Encoded: (object ((str aWQ=) (int 123)) ((str bmFtZQ==) (str VGVzdCBPYmplY3Q=)) ((str dGFncw==) (array (str dGFnMQ==) (str dGFnMg==))) ((str bWV0YWRhdGE=) (object ((str dmVyc2lvbg==) (int 1)) ((str Y3JlYXRlZA==) (str MjAyNS0wMS0wMQ==)))))
+Test (Rust on windows-latest)	Run example	2026-01-08T18:49:39.3513477Z    Decoded name: Some(String("Test Object"))
+Test (Rust on windows-latest)	Run example	2026-01-08T18:49:39.3513799Z    Decoded tags: Some(Array([String("tag1"), String("tag2")]))
+Test (Rust on windows-latest)	Run example	2026-01-08T18:49:39.3514122Z    Decoded metadata.version: Some(Int(1))
+Test (Rust on windows-latest)	Run example	2026-01-08T18:49:39.3514293Z 
+Test (Rust on windows-latest)	Run example	2026-01-08T18:49:39.3514366Z 4. Mixed Type Array:
+Test (Rust on windows-latest)	Run example	2026-01-08T18:49:39.3514629Z    Encoded: (array (int 1) (str aGVsbG8=) (bool true) (null) (float 2.5))
+Test (Rust on windows-latest)	Run example	2026-01-08T18:49:39.3515035Z    Decoded: Array([Int(1), String("hello"), Bool(true), Null, Float(2.5)])
+Test (Rust on windows-latest)	Run example	2026-01-08T18:49:39.3515283Z 
+Test (Rust on windows-latest)	Run example	2026-01-08T18:49:39.3515367Z 5. Roundtrip Verification:
+Test (Rust on windows-latest)	Run example	2026-01-08T18:49:39.3516508Z    Original == Decoded: true
+Test (Rust on windows-latest)	Run example	2026-01-08T18:49:39.3516911Z 
+Test (Rust on windows-latest)	Run example	2026-01-08T18:49:39.3517870Z === Example completed successfully! ===
+Test (Rust on windows-latest)	Post Cache cargo dependencies	﻿2026-01-08T18:49:39.5767089Z Post job cleanup.
+Test (Rust on windows-latest)	Post Cache cargo dependencies	2026-01-08T18:49:39.7562540Z Cache hit occurred on the primary key Windows-cargo-06d79b45cf01dd89665cb7e81015e9ed0cc5bbb8f1a0c5dda8ea1287080b6af5, not saving cache.
+Test (Rust on windows-latest)	Post Run actions/checkout@v4	﻿2026-01-08T18:49:39.7811481Z Post job cleanup.
+Test (Rust on windows-latest)	Post Run actions/checkout@v4	2026-01-08T18:49:40.0093654Z [command]"C:\Program Files\Git\bin\git.exe" version
+Test (Rust on windows-latest)	Post Run actions/checkout@v4	2026-01-08T18:49:40.0378561Z git version 2.52.0.windows.1
+Test (Rust on windows-latest)	Post Run actions/checkout@v4	2026-01-08T18:49:40.0455342Z Temporarily overriding HOME='D:\a\_temp\79f94552-6305-4bab-b5e5-a6c6ae91fb68' before making global git config changes
+Test (Rust on windows-latest)	Post Run actions/checkout@v4	2026-01-08T18:49:40.0456161Z Adding repository directory to the temporary git global config as a safe directory
+Test (Rust on windows-latest)	Post Run actions/checkout@v4	2026-01-08T18:49:40.0466777Z [command]"C:\Program Files\Git\bin\git.exe" config --global --add safe.directory D:\a\lino-objects-codec\lino-objects-codec
+Test (Rust on windows-latest)	Post Run actions/checkout@v4	2026-01-08T18:49:40.0773349Z [command]"C:\Program Files\Git\bin\git.exe" config --local --name-only --get-regexp core\.sshCommand
+Test (Rust on windows-latest)	Post Run actions/checkout@v4	2026-01-08T18:49:40.1072825Z [command]"C:\Program Files\Git\bin\git.exe" submodule foreach --recursive "sh -c \"git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :\""
+Test (Rust on windows-latest)	Post Run actions/checkout@v4	2026-01-08T18:49:40.6399950Z [command]"C:\Program Files\Git\bin\git.exe" config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Test (Rust on windows-latest)	Post Run actions/checkout@v4	2026-01-08T18:49:40.6651302Z http.https://github.com/.extraheader
+Test (Rust on windows-latest)	Post Run actions/checkout@v4	2026-01-08T18:49:40.6695076Z [command]"C:\Program Files\Git\bin\git.exe" config --local --unset-all http.https://github.com/.extraheader
+Test (Rust on windows-latest)	Post Run actions/checkout@v4	2026-01-08T18:49:40.6998779Z [command]"C:\Program Files\Git\bin\git.exe" submodule foreach --recursive "sh -c \"git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :\""
+Test (Rust on windows-latest)	Post Run actions/checkout@v4	2026-01-08T18:49:41.2419400Z [command]"C:\Program Files\Git\bin\git.exe" config --local --name-only --get-regexp ^includeIf\.gitdir:
+Test (Rust on windows-latest)	Post Run actions/checkout@v4	2026-01-08T18:49:41.2727692Z [command]"C:\Program Files\Git\bin\git.exe" submodule foreach --recursive "git config --local --show-origin --name-only --get-regexp remote.origin.url"
+Test (Rust on windows-latest)	Complete job	﻿2026-01-08T18:49:41.8231526Z Cleaning up orphan processes
+Test (Rust on windows-latest)	Complete job	2026-01-08T18:49:41.8425758Z Terminate orphan process: pid (1376) (vctip)
+Test (Rust on ubuntu-latest)	Set up job	﻿2026-01-08T18:48:56.7681920Z Current runner version: '2.330.0'
+Test (Rust on ubuntu-latest)	Set up job	2026-01-08T18:48:56.7708699Z ##[group]Runner Image Provisioner
+Test (Rust on ubuntu-latest)	Set up job	2026-01-08T18:48:56.7709528Z Hosted Compute Agent
+Test (Rust on ubuntu-latest)	Set up job	2026-01-08T18:48:56.7710057Z Version: 20251211.462
+Test (Rust on ubuntu-latest)	Set up job	2026-01-08T18:48:56.7710775Z Commit: 6cbad8c2bb55d58165063d031ccabf57e2d2db61
+Test (Rust on ubuntu-latest)	Set up job	2026-01-08T18:48:56.7711438Z Build Date: 2025-12-11T16:28:49Z
+Test (Rust on ubuntu-latest)	Set up job	2026-01-08T18:48:56.7712085Z Worker ID: {0189505d-abc3-4da9-81f6-33627e88b44f}
+Test (Rust on ubuntu-latest)	Set up job	2026-01-08T18:48:56.7712837Z ##[endgroup]
+Test (Rust on ubuntu-latest)	Set up job	2026-01-08T18:48:56.7713327Z ##[group]Operating System
+Test (Rust on ubuntu-latest)	Set up job	2026-01-08T18:48:56.7713892Z Ubuntu
+Test (Rust on ubuntu-latest)	Set up job	2026-01-08T18:48:56.7714365Z 24.04.3
+Test (Rust on ubuntu-latest)	Set up job	2026-01-08T18:48:56.7715106Z LTS
+Test (Rust on ubuntu-latest)	Set up job	2026-01-08T18:48:56.7715564Z ##[endgroup]
+Test (Rust on ubuntu-latest)	Set up job	2026-01-08T18:48:56.7716113Z ##[group]Runner Image
+Test (Rust on ubuntu-latest)	Set up job	2026-01-08T18:48:56.7716721Z Image: ubuntu-24.04
+Test (Rust on ubuntu-latest)	Set up job	2026-01-08T18:48:56.7717188Z Version: 20251215.174.1
+Test (Rust on ubuntu-latest)	Set up job	2026-01-08T18:48:56.7718559Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20251215.174/images/ubuntu/Ubuntu2404-Readme.md
+Test (Rust on ubuntu-latest)	Set up job	2026-01-08T18:48:56.7719945Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20251215.174
+Test (Rust on ubuntu-latest)	Set up job	2026-01-08T18:48:56.7721645Z ##[endgroup]
+Test (Rust on ubuntu-latest)	Set up job	2026-01-08T18:48:56.7724268Z ##[group]GITHUB_TOKEN Permissions
+Test (Rust on ubuntu-latest)	Set up job	2026-01-08T18:48:56.7726744Z Actions: write
+Test (Rust on ubuntu-latest)	Set up job	2026-01-08T18:48:56.7727452Z ArtifactMetadata: write
+Test (Rust on ubuntu-latest)	Set up job	2026-01-08T18:48:56.7727975Z Attestations: write
+Test (Rust on ubuntu-latest)	Set up job	2026-01-08T18:48:56.7728469Z Checks: write
+Test (Rust on ubuntu-latest)	Set up job	2026-01-08T18:48:56.7729028Z Contents: write
+Test (Rust on ubuntu-latest)	Set up job	2026-01-08T18:48:56.7729481Z Deployments: write
+Test (Rust on ubuntu-latest)	Set up job	2026-01-08T18:48:56.7730009Z Discussions: write
+Test (Rust on ubuntu-latest)	Set up job	2026-01-08T18:48:56.7730542Z Issues: write
+Test (Rust on ubuntu-latest)	Set up job	2026-01-08T18:48:56.7731017Z Metadata: read
+Test (Rust on ubuntu-latest)	Set up job	2026-01-08T18:48:56.7731463Z Models: read
+Test (Rust on ubuntu-latest)	Set up job	2026-01-08T18:48:56.7731999Z Packages: write
+Test (Rust on ubuntu-latest)	Set up job	2026-01-08T18:48:56.7732449Z Pages: write
+Test (Rust on ubuntu-latest)	Set up job	2026-01-08T18:48:56.7732962Z PullRequests: write
+Test (Rust on ubuntu-latest)	Set up job	2026-01-08T18:48:56.7733631Z RepositoryProjects: write
+Test (Rust on ubuntu-latest)	Set up job	2026-01-08T18:48:56.7734170Z SecurityEvents: write
+Test (Rust on ubuntu-latest)	Set up job	2026-01-08T18:48:56.7734886Z Statuses: write
+Test (Rust on ubuntu-latest)	Set up job	2026-01-08T18:48:56.7735413Z ##[endgroup]
+Test (Rust on ubuntu-latest)	Set up job	2026-01-08T18:48:56.7737962Z Secret source: Actions
+Test (Rust on ubuntu-latest)	Set up job	2026-01-08T18:48:56.7738906Z Prepare workflow directory
+Test (Rust on ubuntu-latest)	Set up job	2026-01-08T18:48:56.8172600Z Prepare all required actions
+Test (Rust on ubuntu-latest)	Set up job	2026-01-08T18:48:56.8227695Z Getting action download info
+Test (Rust on ubuntu-latest)	Set up job	2026-01-08T18:48:57.1651039Z Download action repository 'actions/checkout@v4' (SHA:34e114876b0b11c390a56381ad16ebd13914f8d5)
+Test (Rust on ubuntu-latest)	Set up job	2026-01-08T18:48:57.2631258Z Download action repository 'dtolnay/rust-toolchain@stable' (SHA:4be9e76fd7c4901c61fb841f559994984270fce7)
+Test (Rust on ubuntu-latest)	Set up job	2026-01-08T18:48:57.5764039Z Download action repository 'actions/cache@v4' (SHA:0057852bfaa89a56745cba8c7296529d2fc39830)
+Test (Rust on ubuntu-latest)	Set up job	2026-01-08T18:48:57.8044066Z Complete job name: Test (Rust on ubuntu-latest)
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	﻿2026-01-08T18:48:57.8748350Z ##[group]Run actions/checkout@v4
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:57.8749216Z with:
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:57.8749687Z   repository: link-foundation/lino-objects-codec
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:57.8750415Z   token: ***
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:57.8750798Z   ssh-strict: true
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:57.8751177Z   ssh-user: git
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:57.8751576Z   persist-credentials: true
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:57.8752008Z   clean: true
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:57.8752426Z   sparse-checkout-cone-mode: true
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:57.8752904Z   fetch-depth: 1
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:57.8753282Z   fetch-tags: false
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:57.8753682Z   show-progress: true
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:57.8754074Z   lfs: false
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:57.8754437Z   submodules: false
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:57.8755189Z   set-safe-directory: true
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:57.8756027Z env:
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:57.8756416Z   CARGO_TERM_COLOR: always
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:57.8756867Z   RUSTFLAGS: -Dwarnings
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:57.8757277Z ##[endgroup]
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:57.9853704Z Syncing repository: link-foundation/lino-objects-codec
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:57.9857283Z ##[group]Getting Git version info
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:57.9858727Z Working directory is '/home/runner/work/lino-objects-codec/lino-objects-codec'
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:57.9860714Z [command]/usr/bin/git version
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:57.9948244Z git version 2.52.0
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:57.9975403Z ##[endgroup]
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:57.9997618Z Temporarily overriding HOME='/home/runner/work/_temp/181c4b28-a7f9-4e69-8090-8a6fb64f7dce' before making global git config changes
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:57.9999311Z Adding repository directory to the temporary git global config as a safe directory
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.0002771Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/lino-objects-codec/lino-objects-codec
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.0043639Z Deleting the contents of '/home/runner/work/lino-objects-codec/lino-objects-codec'
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.0047341Z ##[group]Initializing the repository
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.0051219Z [command]/usr/bin/git init /home/runner/work/lino-objects-codec/lino-objects-codec
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.0165046Z hint: Using 'master' as the name for the initial branch. This default branch name
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.0166451Z hint: will change to "main" in Git 3.0. To configure the initial branch name
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.0168089Z hint: to use in all of your new repositories, which will suppress this warning,
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.0169327Z hint: call:
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.0169959Z hint:
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.0170716Z hint: 	git config --global init.defaultBranch <name>
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.0171660Z hint:
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.0172230Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.0173131Z hint: 'development'. The just-created branch can be renamed via this command:
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.0173830Z hint:
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.0174195Z hint: 	git branch -m <name>
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.0174632Z hint:
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.0175474Z hint: Disable this message with "git config set advice.defaultBranchName false"
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.0177083Z Initialized empty Git repository in /home/runner/work/lino-objects-codec/lino-objects-codec/.git/
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.0182210Z [command]/usr/bin/git remote add origin https://github.com/link-foundation/lino-objects-codec
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.0217924Z ##[endgroup]
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.0219181Z ##[group]Disabling automatic garbage collection
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.0222728Z [command]/usr/bin/git config --local gc.auto 0
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.0250682Z ##[endgroup]
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.0251391Z ##[group]Setting up auth
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.0257458Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.0287219Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.0658963Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.0692713Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.0967805Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.1007119Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.1263394Z [command]/usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.2937295Z ##[endgroup]
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.2938786Z ##[group]Fetching the repository
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.2946324Z [command]/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +c79c77d68a90cadbd439c9613a7050501095c92d:refs/remotes/origin/main
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.7709538Z From https://github.com/link-foundation/lino-objects-codec
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.7711487Z  * [new ref]         c79c77d68a90cadbd439c9613a7050501095c92d -> origin/main
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.7742716Z ##[endgroup]
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.7743821Z ##[group]Determining the checkout info
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.7745592Z ##[endgroup]
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.7749969Z [command]/usr/bin/git sparse-checkout disable
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.7792065Z [command]/usr/bin/git config --local --unset-all extensions.worktreeConfig
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.7817466Z ##[group]Checking out the ref
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.7820549Z [command]/usr/bin/git checkout --progress --force -B main refs/remotes/origin/main
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.7950051Z Switched to a new branch 'main'
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.7952837Z branch 'main' set up to track 'origin/main'.
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.7960110Z ##[endgroup]
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.7991478Z [command]/usr/bin/git log -1 --format=%H
+Test (Rust on ubuntu-latest)	Run actions/checkout@v4	2026-01-08T18:48:58.8012729Z c79c77d68a90cadbd439c9613a7050501095c92d
+Test (Rust on ubuntu-latest)	Set up Rust	﻿2026-01-08T18:48:58.8678181Z ##[group]Run dtolnay/rust-toolchain@stable
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.8679221Z with:
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.8679838Z   toolchain: stable
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.8680521Z env:
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.8681136Z   CARGO_TERM_COLOR: always
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.8681941Z   RUSTFLAGS: -Dwarnings
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.8682669Z ##[endgroup]
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.8819871Z ##[group]Run : parse toolchain version
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.8820932Z [36;1m: parse toolchain version[0m
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.8821853Z [36;1mif [[ -z $toolchain ]]; then[0m
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.8823587Z [36;1m  # GitHub does not enforce `required: true` inputs itself. https://github.com/actions/runner/issues/1070[0m
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.8825909Z [36;1m  echo "'toolchain' is a required input" >&2[0m
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.8826944Z [36;1m  exit 1[0m
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.8828062Z [36;1melif [[ $toolchain =~ ^stable' '[0-9]+' '(year|month|week|day)s?' 'ago$ ]]; then[0m
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.8829448Z [36;1m  if [[ Linux == macOS ]]; then[0m
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.8831221Z [36;1m    echo "toolchain=1.$((($(date -v-$(sed 's/stable \([0-9]*\) \(.\).*/\1\2/' <<< $toolchain) +%s)/60/60/24-16569)/7/6))" >> $GITHUB_OUTPUT[0m
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.8833005Z [36;1m  else[0m
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.8834345Z [36;1m    echo "toolchain=1.$((($(date --date "${toolchain#stable }" +%s)/60/60/24-16569)/7/6))" >> $GITHUB_OUTPUT[0m
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.8836036Z [36;1m  fi[0m
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.8837018Z [36;1melif [[ $toolchain =~ ^stable' 'minus' '[0-9]+' 'releases?$ ]]; then[0m
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.8838828Z [36;1m  echo "toolchain=1.$((($(date +%s)/60/60/24-16569)/7/6-${toolchain//[^0-9]/}))" >> $GITHUB_OUTPUT[0m
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.8840420Z [36;1melif [[ $toolchain =~ ^1\.[0-9]+$ ]]; then[0m
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.8842260Z [36;1m  echo "toolchain=1.$((i=${toolchain#1.}, c=($(date +%s)/60/60/24-16569)/7/6, i+9*i*(10*i<=c)+90*i*(100*i<=c)))" >> $GITHUB_OUTPUT[0m
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.8843963Z [36;1melse[0m
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.8844864Z [36;1m  echo "toolchain=$toolchain" >> $GITHUB_OUTPUT[0m
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.8845900Z [36;1mfi[0m
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.8886258Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.8887406Z env:
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.8887997Z   CARGO_TERM_COLOR: always
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.8888759Z   RUSTFLAGS: -Dwarnings
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.8889466Z   toolchain: stable
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.8890104Z ##[endgroup]
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.9137709Z ##[group]Run : construct rustup command line
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.9138779Z [36;1m: construct rustup command line[0m
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.9140301Z [36;1mecho "targets=$(for t in ${targets//,/ }; do echo -n ' --target' $t; done)" >> $GITHUB_OUTPUT[0m
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.9142478Z [36;1mecho "components=$(for c in ${components//,/ }; do echo -n ' --component' $c; done)" >> $GITHUB_OUTPUT[0m
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.9144137Z [36;1mecho "downgrade=" >> $GITHUB_OUTPUT[0m
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.9179167Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.9180253Z env:
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.9180843Z   CARGO_TERM_COLOR: always
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.9181637Z   RUSTFLAGS: -Dwarnings
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.9182329Z   targets: 
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.9182922Z   components: 
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.9183528Z ##[endgroup]
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.9296526Z ##[group]Run : set $CARGO_HOME
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.9297394Z [36;1m: set $CARGO_HOME[0m
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.9298459Z [36;1mecho CARGO_HOME=${CARGO_HOME:-"$HOME/.cargo"} >> $GITHUB_ENV[0m
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.9333089Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.9334186Z env:
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.9335181Z   CARGO_TERM_COLOR: always
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.9335959Z   RUSTFLAGS: -Dwarnings
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.9336786Z ##[endgroup]
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.9448341Z ##[group]Run : install rustup if needed
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.9449325Z [36;1m: install rustup if needed[0m
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.9450306Z [36;1mif ! command -v rustup &>/dev/null; then[0m
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.9452933Z [36;1m  curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused --location --silent --show-error --fail https://sh.rustup.rs | sh -s -- --default-toolchain none -y[0m
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.9455974Z [36;1m  echo "$CARGO_HOME/bin" >> $GITHUB_PATH[0m
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.9456949Z [36;1mfi[0m
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.9491379Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.9492483Z env:
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.9493083Z   CARGO_TERM_COLOR: always
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.9493857Z   RUSTFLAGS: -Dwarnings
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.9494609Z   CARGO_HOME: /home/runner/.cargo
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.9495605Z ##[endgroup]
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.9612136Z ##[group]Run rustup toolchain install stable --profile minimal --no-self-update
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.9613923Z [36;1mrustup toolchain install stable --profile minimal --no-self-update[0m
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.9650911Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.9652802Z env:
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.9653466Z   CARGO_TERM_COLOR: always
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.9654264Z   RUSTFLAGS: -Dwarnings
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.9655202Z   CARGO_HOME: /home/runner/.cargo
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.9656094Z   RUSTUP_PERMIT_COPY_RENAME: 1
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:58.9656865Z ##[endgroup]
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.1843314Z info: syncing channel updates for 'stable-x86_64-unknown-linux-gnu'
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.2936242Z 
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.3032782Z   stable-x86_64-unknown-linux-gnu unchanged - rustc 1.92.0 (ded5c06cf 2025-12-08)
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.3033441Z 
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.3082767Z ##[group]Run rustup default stable
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.3083107Z [36;1mrustup default stable[0m
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.3120862Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.3121244Z env:
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.3121464Z   CARGO_TERM_COLOR: always
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.3121722Z   RUSTFLAGS: -Dwarnings
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.3121987Z   CARGO_HOME: /home/runner/.cargo
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.3122256Z ##[endgroup]
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.3229245Z info: using existing install for 'stable-x86_64-unknown-linux-gnu'
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.3592347Z info: default toolchain set to 'stable-x86_64-unknown-linux-gnu'
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.3592869Z 
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.3682028Z   stable-x86_64-unknown-linux-gnu unchanged - rustc 1.92.0 (ded5c06cf 2025-12-08)
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.3682470Z 
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.3732900Z ##[group]Run : create cachekey
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.3733226Z [36;1m: create cachekey[0m
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.3733767Z [36;1mDATE=$(rustc +stable --version --verbose | sed -ne 's/^commit-date: \(20[0-9][0-9]\)-\([01][0-9]\)-\([0-3][0-9]\)$/\1\2\3/p')[0m
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.3734452Z [36;1mHASH=$(rustc +stable --version --verbose | sed -ne 's/^commit-hash: //p')[0m
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.3735561Z [36;1mecho "cachekey=$(echo $DATE$HASH | head -c12)" >> $GITHUB_OUTPUT[0m
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.3772833Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.3773221Z env:
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.3773446Z   CARGO_TERM_COLOR: always
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.3773702Z   RUSTFLAGS: -Dwarnings
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.3773971Z   CARGO_HOME: /home/runner/.cargo
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.3774248Z ##[endgroup]
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.4197325Z ##[group]Run : disable incremental compilation
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.4197776Z [36;1m: disable incremental compilation[0m
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.4198129Z [36;1mif [ -z "${CARGO_INCREMENTAL+set}" ]; then[0m
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.4198504Z [36;1m  echo CARGO_INCREMENTAL=0 >> $GITHUB_ENV[0m
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.4198822Z [36;1mfi[0m
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.4236242Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.4236639Z env:
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.4236853Z   CARGO_TERM_COLOR: always
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.4237301Z   RUSTFLAGS: -Dwarnings
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.4237560Z   CARGO_HOME: /home/runner/.cargo
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.4237838Z ##[endgroup]
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.4364538Z ##[group]Run : enable colors in Cargo output
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.4365185Z [36;1m: enable colors in Cargo output[0m
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.4365549Z [36;1mif [ -z "${CARGO_TERM_COLOR+set}" ]; then[0m
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.4365934Z [36;1m  echo CARGO_TERM_COLOR=always >> $GITHUB_ENV[0m
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.4366462Z [36;1mfi[0m
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.4399985Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.4400379Z env:
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.4400591Z   CARGO_TERM_COLOR: always
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.4400859Z   RUSTFLAGS: -Dwarnings
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.4401117Z   CARGO_HOME: /home/runner/.cargo
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.4401392Z   CARGO_INCREMENTAL: 0
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.4401620Z ##[endgroup]
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.4478317Z ##[group]Run : enable Cargo sparse registry
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.4478704Z [36;1m: enable Cargo sparse registry[0m
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.4479111Z [36;1m# implemented in 1.66, stabilized in 1.68, made default in 1.70[0m
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.4479865Z [36;1mif [ -z "${CARGO_REGISTRIES_CRATES_IO_PROTOCOL+set}" -o -f "/home/runner/work/_temp"/.implicit_cargo_registries_crates_io_protocol ]; then[0m
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.4480650Z [36;1m  if rustc +stable --version --verbose | grep -q '^release: 1\.6[89]\.'; then[0m
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.4481272Z [36;1m    touch "/home/runner/work/_temp"/.implicit_cargo_registries_crates_io_protocol || true[0m
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.4481865Z [36;1m    echo CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse >> $GITHUB_ENV[0m
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.4482399Z [36;1m  elif rustc +stable --version --verbose | grep -q '^release: 1\.6[67]\.'; then[0m
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.4483016Z [36;1m    touch "/home/runner/work/_temp"/.implicit_cargo_registries_crates_io_protocol || true[0m
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.4483588Z [36;1m    echo CARGO_REGISTRIES_CRATES_IO_PROTOCOL=git >> $GITHUB_ENV[0m
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.4483963Z [36;1m  fi[0m
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.4484173Z [36;1mfi[0m
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.4517835Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.4518212Z env:
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.4518433Z   CARGO_TERM_COLOR: always
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.4518686Z   RUSTFLAGS: -Dwarnings
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.4518947Z   CARGO_HOME: /home/runner/.cargo
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.4519214Z   CARGO_INCREMENTAL: 0
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.4519447Z ##[endgroup]
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.4892845Z ##[group]Run : work around spurious network errors in curl 8.0
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.4893356Z [36;1m: work around spurious network errors in curl 8.0[0m
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.4893965Z [36;1m# https://rust-lang.zulipchat.com/#narrow/stream/246057-t-cargo/topic/timeout.20investigation[0m
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.4894623Z [36;1mif rustc +stable --version --verbose | grep -q '^release: 1\.7[01]\.'; then[0m
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.4895454Z [36;1m  echo CARGO_HTTP_MULTIPLEXING=false >> $GITHUB_ENV[0m
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.4895811Z [36;1mfi[0m
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.4933110Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.4933493Z env:
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.4933705Z   CARGO_TERM_COLOR: always
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.4933966Z   RUSTFLAGS: -Dwarnings
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.4934217Z   CARGO_HOME: /home/runner/.cargo
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.4934488Z   CARGO_INCREMENTAL: 0
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.4934925Z ##[endgroup]
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.5159323Z ##[group]Run rustc +stable --version --verbose
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.5159755Z [36;1mrustc +stable --version --verbose[0m
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.5196303Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.5196680Z env:
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.5196897Z   CARGO_TERM_COLOR: always
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.5197150Z   RUSTFLAGS: -Dwarnings
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.5197405Z   CARGO_HOME: /home/runner/.cargo
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.5197678Z   CARGO_INCREMENTAL: 0
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.5197912Z ##[endgroup]
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.5381829Z rustc 1.92.0 (ded5c06cf 2025-12-08)
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.5383228Z binary: rustc
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.5383652Z commit-hash: ded5c06cf21d2b93bffd5d884aa6e96934ee4234
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.5384037Z commit-date: 2025-12-08
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.5384324Z host: x86_64-unknown-linux-gnu
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.5384610Z release: 1.92.0
+Test (Rust on ubuntu-latest)	Set up Rust	2026-01-08T18:48:59.5385233Z LLVM version: 21.1.3
+Test (Rust on ubuntu-latest)	Cache cargo dependencies	﻿2026-01-08T18:48:59.6039619Z ##[group]Run actions/cache@v4
+Test (Rust on ubuntu-latest)	Cache cargo dependencies	2026-01-08T18:48:59.6039970Z with:
+Test (Rust on ubuntu-latest)	Cache cargo dependencies	2026-01-08T18:48:59.6040388Z   path: ~/.cargo/bin/
+Test (Rust on ubuntu-latest)	Cache cargo dependencies	~/.cargo/registry/index/
+Test (Rust on ubuntu-latest)	Cache cargo dependencies	~/.cargo/registry/cache/
+Test (Rust on ubuntu-latest)	Cache cargo dependencies	~/.cargo/git/db/
+Test (Rust on ubuntu-latest)	Cache cargo dependencies	rust/target/
+Test (Rust on ubuntu-latest)	Cache cargo dependencies	
+Test (Rust on ubuntu-latest)	Cache cargo dependencies	2026-01-08T18:48:59.6041058Z   key: Linux-cargo-3bdf1052f98aec50857f27e3615100242b9f9c1f98c417d8384cf7fd70b81aba
+Test (Rust on ubuntu-latest)	Cache cargo dependencies	2026-01-08T18:48:59.6041525Z   enableCrossOsArchive: false
+Test (Rust on ubuntu-latest)	Cache cargo dependencies	2026-01-08T18:48:59.6041801Z   fail-on-cache-miss: false
+Test (Rust on ubuntu-latest)	Cache cargo dependencies	2026-01-08T18:48:59.6042062Z   lookup-only: false
+Test (Rust on ubuntu-latest)	Cache cargo dependencies	2026-01-08T18:48:59.6042295Z   save-always: false
+Test (Rust on ubuntu-latest)	Cache cargo dependencies	2026-01-08T18:48:59.6042509Z env:
+Test (Rust on ubuntu-latest)	Cache cargo dependencies	2026-01-08T18:48:59.6042718Z   CARGO_TERM_COLOR: always
+Test (Rust on ubuntu-latest)	Cache cargo dependencies	2026-01-08T18:48:59.6042971Z   RUSTFLAGS: -Dwarnings
+Test (Rust on ubuntu-latest)	Cache cargo dependencies	2026-01-08T18:48:59.6043253Z   CARGO_HOME: /home/runner/.cargo
+Test (Rust on ubuntu-latest)	Cache cargo dependencies	2026-01-08T18:48:59.6043524Z   CARGO_INCREMENTAL: 0
+Test (Rust on ubuntu-latest)	Cache cargo dependencies	2026-01-08T18:48:59.6043756Z ##[endgroup]
+Test (Rust on ubuntu-latest)	Cache cargo dependencies	2026-01-08T18:48:59.8752986Z Cache hit for: Linux-cargo-3bdf1052f98aec50857f27e3615100242b9f9c1f98c417d8384cf7fd70b81aba
+Test (Rust on ubuntu-latest)	Cache cargo dependencies	2026-01-08T18:49:00.6695531Z Received 8743147 of 8743147 (100.0%), 12.9 MBs/sec
+Test (Rust on ubuntu-latest)	Cache cargo dependencies	2026-01-08T18:49:00.6696624Z Cache Size: ~8 MB (8743147 B)
+Test (Rust on ubuntu-latest)	Cache cargo dependencies	2026-01-08T18:49:00.6721694Z [command]/usr/bin/tar -xf /home/runner/work/_temp/9014a11f-456b-46bd-89f5-edaf22158786/cache.tzst -P -C /home/runner/work/lino-objects-codec/lino-objects-codec --use-compress-program unzstd
+Test (Rust on ubuntu-latest)	Cache cargo dependencies	2026-01-08T18:49:00.7226776Z Cache restored successfully
+Test (Rust on ubuntu-latest)	Cache cargo dependencies	2026-01-08T18:49:00.7325877Z Cache restored from key: Linux-cargo-3bdf1052f98aec50857f27e3615100242b9f9c1f98c417d8384cf7fd70b81aba
+Test (Rust on ubuntu-latest)	Run tests	﻿2026-01-08T18:49:00.7418949Z ##[group]Run cargo test --verbose
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:00.7419285Z [36;1mcargo test --verbose[0m
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:00.7452665Z shell: /usr/bin/bash -e {0}
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:00.7452937Z env:
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:00.7453124Z   CARGO_TERM_COLOR: always
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:00.7453367Z   RUSTFLAGS: -Dwarnings
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:00.7453606Z   CARGO_HOME: /home/runner/.cargo
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:00.7453867Z   CARGO_INCREMENTAL: 0
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:00.7454081Z ##[endgroup]
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:00.9585530Z [1m[92m   Compiling[0m memchr v2.7.6
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:00.9586217Z [1m[92m   Compiling[0m base64 v0.22.1
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:00.9601698Z [1m[92m     Running[0m `/home/runner/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustc --crate-name memchr --edition=2021 /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/memchr-2.7.6/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debuginfo=2 --cfg 'feature="alloc"' --cfg 'feature="std"' --check-cfg 'cfg(docsrs,test)' --check-cfg 'cfg(feature, values("alloc", "core", "default", "libc", "logging", "rustc-dep-of-std", "std", "use_std"))' -C metadata=6ba170fd55331a9a -C extra-filename=-6431e2fba5201ce0 --out-dir /home/runner/work/lino-objects-codec/lino-objects-codec/rust/target/debug/deps -L dependency=/home/runner/work/lino-objects-codec/lino-objects-codec/rust/target/debug/deps --cap-lints allow -Dwarnings`
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:00.9613925Z [1m[92m     Running[0m `/home/runner/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustc --crate-name base64 --edition=2018 /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/base64-0.22.1/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debuginfo=2 --cfg 'feature="alloc"' --cfg 'feature="default"' --cfg 'feature="std"' --check-cfg 'cfg(docsrs,test)' --check-cfg 'cfg(feature, values("alloc", "default", "std"))' -C metadata=5dfde4b87f3a4613 -C extra-filename=-62024e2fc86e6def --out-dir /home/runner/work/lino-objects-codec/lino-objects-codec/rust/target/debug/deps -L dependency=/home/runner/work/lino-objects-codec/lino-objects-codec/rust/target/debug/deps --cap-lints allow -Dwarnings`
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:01.3738441Z [1m[92m   Compiling[0m nom v8.0.0
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:01.3768590Z [1m[92m     Running[0m `/home/runner/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustc --crate-name nom --edition=2021 /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nom-8.0.0/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debuginfo=2 --cfg 'feature="alloc"' --cfg 'feature="default"' --cfg 'feature="std"' --check-cfg 'cfg(docsrs,test)' --check-cfg 'cfg(feature, values("alloc", "default", "docsrs", "std"))' -C metadata=7c2e98842d051afd -C extra-filename=-b1f37d207949a516 --out-dir /home/runner/work/lino-objects-codec/lino-objects-codec/rust/target/debug/deps -L dependency=/home/runner/work/lino-objects-codec/lino-objects-codec/rust/target/debug/deps --extern memchr=/home/runner/work/lino-objects-codec/lino-objects-codec/rust/target/debug/deps/libmemchr-6431e2fba5201ce0.rmeta --cap-lints allow -Dwarnings`
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:03.2009902Z [1m[92m   Compiling[0m links-notation v0.13.0
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:03.2018709Z [1m[92m     Running[0m `/home/runner/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustc --crate-name links_notation --edition=2021 /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/links-notation-0.13.0/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debuginfo=2 --check-cfg 'cfg(docsrs,test)' --check-cfg 'cfg(feature, values())' -C metadata=b24d35c6130e3050 -C extra-filename=-6442fd1e4c838579 --out-dir /home/runner/work/lino-objects-codec/lino-objects-codec/rust/target/debug/deps -L dependency=/home/runner/work/lino-objects-codec/lino-objects-codec/rust/target/debug/deps --extern nom=/home/runner/work/lino-objects-codec/lino-objects-codec/rust/target/debug/deps/libnom-b1f37d207949a516.rmeta --cap-lints allow -Dwarnings`
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:03.4207787Z [1m[92m   Compiling[0m lino-objects-codec v0.2.0 (/home/runner/work/lino-objects-codec/lino-objects-codec/rust)
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:03.4232900Z [1m[92m     Running[0m `/home/runner/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustc --crate-name lino_objects_codec --edition=2021 src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debuginfo=2 '--warn=clippy::pedantic' '--warn=clippy::nursery' '--warn=clippy::all' '--allow=clippy::use_self' '--allow=clippy::unused_self' '--allow=clippy::unreadable_literal' '--allow=clippy::uninlined_format_args' '--allow=clippy::too_many_lines' '--allow=clippy::similar_names' '--allow=clippy::redundant_closure_for_method_calls' '--allow=clippy::redundant_clone' '--allow=clippy::option_if_let_else' '--allow=clippy::must_use_candidate' '--allow=clippy::module_name_repetitions' '--allow=clippy::missing_panics_doc' '--allow=clippy::missing_errors_doc' '--allow=clippy::missing_const_for_fn' '--allow=clippy::inefficient_to_string' '--allow=clippy::ignored_unit_patterns' '--allow=clippy::if_not_else' '--allow=clippy::doc_markdown' '--allow=clippy::derive_partial_eq_without_eq' '--allow=clippy::cast_precision_loss' '--allow=clippy::cast_lossless' '--allow=clippy::assigning_clones' '--allow=clippy::approx_constant' --check-cfg 'cfg(docsrs,test)' --check-cfg 'cfg(feature, values())' -C metadata=13c7ef0777f38441 -C extra-filename=-08c4ff317c658dd0 --out-dir /home/runner/work/lino-objects-codec/lino-objects-codec/rust/target/debug/deps -L dependency=/home/runner/work/lino-objects-codec/lino-objects-codec/rust/target/debug/deps --extern base64=/home/runner/work/lino-objects-codec/lino-objects-codec/rust/target/debug/deps/libbase64-62024e2fc86e6def.rmeta --extern links_notation=/home/runner/work/lino-objects-codec/lino-objects-codec/rust/target/debug/deps/liblinks_notation-6442fd1e4c838579.rmeta -Dwarnings`
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:03.6220794Z [1m[92m     Running[0m `/home/runner/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustc --crate-name lino_objects_codec --edition=2021 src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --emit=dep-info,link -C embed-bitcode=no -C debuginfo=2 '--warn=clippy::pedantic' '--warn=clippy::nursery' '--warn=clippy::all' '--allow=clippy::use_self' '--allow=clippy::unused_self' '--allow=clippy::unreadable_literal' '--allow=clippy::uninlined_format_args' '--allow=clippy::too_many_lines' '--allow=clippy::similar_names' '--allow=clippy::redundant_closure_for_method_calls' '--allow=clippy::redundant_clone' '--allow=clippy::option_if_let_else' '--allow=clippy::must_use_candidate' '--allow=clippy::module_name_repetitions' '--allow=clippy::missing_panics_doc' '--allow=clippy::missing_errors_doc' '--allow=clippy::missing_const_for_fn' '--allow=clippy::inefficient_to_string' '--allow=clippy::ignored_unit_patterns' '--allow=clippy::if_not_else' '--allow=clippy::doc_markdown' '--allow=clippy::derive_partial_eq_without_eq' '--allow=clippy::cast_precision_loss' '--allow=clippy::cast_lossless' '--allow=clippy::assigning_clones' '--allow=clippy::approx_constant' --test --check-cfg 'cfg(docsrs,test)' --check-cfg 'cfg(feature, values())' -C metadata=b984e3d632fe8566 -C extra-filename=-0c5284b88ad8f486 --out-dir /home/runner/work/lino-objects-codec/lino-objects-codec/rust/target/debug/deps -L dependency=/home/runner/work/lino-objects-codec/lino-objects-codec/rust/target/debug/deps --extern base64=/home/runner/work/lino-objects-codec/lino-objects-codec/rust/target/debug/deps/libbase64-62024e2fc86e6def.rlib --extern links_notation=/home/runner/work/lino-objects-codec/lino-objects-codec/rust/target/debug/deps/liblinks_notation-6442fd1e4c838579.rlib -Dwarnings`
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:03.7822720Z [1m[92m     Running[0m `/home/runner/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustc --crate-name basic_usage --edition=2021 examples/basic_usage.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --crate-type bin --emit=dep-info,link -C embed-bitcode=no -C debuginfo=2 '--warn=clippy::pedantic' '--warn=clippy::nursery' '--warn=clippy::all' '--allow=clippy::use_self' '--allow=clippy::unused_self' '--allow=clippy::unreadable_literal' '--allow=clippy::uninlined_format_args' '--allow=clippy::too_many_lines' '--allow=clippy::similar_names' '--allow=clippy::redundant_closure_for_method_calls' '--allow=clippy::redundant_clone' '--allow=clippy::option_if_let_else' '--allow=clippy::must_use_candidate' '--allow=clippy::module_name_repetitions' '--allow=clippy::missing_panics_doc' '--allow=clippy::missing_errors_doc' '--allow=clippy::missing_const_for_fn' '--allow=clippy::inefficient_to_string' '--allow=clippy::ignored_unit_patterns' '--allow=clippy::if_not_else' '--allow=clippy::doc_markdown' '--allow=clippy::derive_partial_eq_without_eq' '--allow=clippy::cast_precision_loss' '--allow=clippy::cast_lossless' '--allow=clippy::assigning_clones' '--allow=clippy::approx_constant' --check-cfg 'cfg(docsrs,test)' --check-cfg 'cfg(feature, values())' -C metadata=99f9b112acc60442 -C extra-filename=-bed4ef3baf54f81a --out-dir /home/runner/work/lino-objects-codec/lino-objects-codec/rust/target/debug/examples -L dependency=/home/runner/work/lino-objects-codec/lino-objects-codec/rust/target/debug/deps --extern base64=/home/runner/work/lino-objects-codec/lino-objects-codec/rust/target/debug/deps/libbase64-62024e2fc86e6def.rlib --extern links_notation=/home/runner/work/lino-objects-codec/lino-objects-codec/rust/target/debug/deps/liblinks_notation-6442fd1e4c838579.rlib --extern lino_objects_codec=/home/runner/work/lino-objects-codec/lino-objects-codec/rust/target/debug/deps/liblino_objects_codec-08c4ff317c658dd0.rlib -Dwarnings`
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:04.1550069Z [1m[92m    Finished[0m `test` profile [unoptimized + debuginfo] target(s) in 3.33s
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:04.1560247Z [1m[92m     Running[0m `/home/runner/work/lino-objects-codec/lino-objects-codec/rust/target/debug/deps/lino_objects_codec-0c5284b88ad8f486`
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:04.1570713Z 
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:04.1570895Z running 32 tests
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:04.1574662Z test format_tests::test_escape_reference_simple_string ... ok
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:04.1575875Z test format_tests::test_escape_reference_string_with_single_quotes ... ok
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:04.1576734Z test format_tests::test_escape_reference_string_with_spaces ... ok
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:04.1577920Z test format_tests::test_format_indented_ordered_basic ... ok
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:04.1578845Z test format_tests::test_format_indented_requires_id ... ok
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:04.1579558Z test format_tests::test_escape_reference_string_with_double_quotes ... ok
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:04.1581583Z test format_tests::test_format_indented_value_with_quotes ... ok
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:04.1582504Z test format_tests::test_parse_indented_empty_lines_skipped ... ok
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:04.1584583Z test format_tests::test_parse_indented_basic ... ok
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:04.1585832Z test format_tests::test_parse_indented_requires_text ... ok
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:04.1586491Z test format_tests::test_roundtrip_format_indented ... ok
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:04.1587747Z test format_tests::test_parse_indented_with_quotes ... ok
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:04.1588405Z test format_tests::test_roundtrip_with_quotes ... ok
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:04.1590854Z test format_tests::test_unescape_reference_doubled_quotes ... ok
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:04.1594613Z test tests::test_float_special_values ... ok
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:04.1595668Z test tests::test_dict_of_lists ... ok
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:04.1596360Z test tests::test_list_of_dicts ... ok
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:04.1596911Z test tests::test_complex_structure ... ok
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:04.1597448Z test tests::test_nested_arrays ... ok
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:04.1598004Z test tests::test_roundtrip_empty_object ... ok
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:04.1600233Z test tests::test_nested_objects ... ok
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:04.1603863Z test tests::test_roundtrip_bool ... ok
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:04.1604555Z test tests::test_roundtrip_float ... ok
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:04.1605689Z test tests::test_roundtrip_empty_array ... ok
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:04.1606634Z test tests::test_roundtrip_int ... ok
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:04.1608906Z test tests::test_roundtrip_mixed_array ... ok
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:04.1609740Z test tests::test_roundtrip_simple_array ... ok
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:04.1610514Z test tests::test_roundtrip_null ... ok
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:04.1611232Z test tests::test_roundtrip_simple_object ... ok
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:04.1612386Z test tests::test_string_with_quotes ... ok
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:04.1612893Z test tests::test_roundtrip_string ... ok
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:04.1614517Z test tests::test_unicode_string ... ok
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:04.1614996Z 
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:04.1615276Z test result: ok. 32 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:04.1615644Z 
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:04.1616671Z [1m[92m   Doc-tests[0m lino_objects_codec
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:04.1626394Z [1m[92m     Running[0m `/home/runner/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustdoc --edition=2021 --crate-type lib --color always --crate-name lino_objects_codec --test src/lib.rs --test-run-directory /home/runner/work/lino-objects-codec/lino-objects-codec/rust -L dependency=/home/runner/work/lino-objects-codec/lino-objects-codec/rust/target/debug/deps -L dependency=/home/runner/work/lino-objects-codec/lino-objects-codec/rust/target/debug/deps '--warn=clippy::pedantic' '--warn=clippy::nursery' '--warn=clippy::all' '--allow=clippy::use_self' '--allow=clippy::unused_self' '--allow=clippy::unreadable_literal' '--allow=clippy::uninlined_format_args' '--allow=clippy::too_many_lines' '--allow=clippy::similar_names' '--allow=clippy::redundant_closure_for_method_calls' '--allow=clippy::redundant_clone' '--allow=clippy::option_if_let_else' '--allow=clippy::must_use_candidate' '--allow=clippy::module_name_repetitions' '--allow=clippy::missing_panics_doc' '--allow=clippy::missing_errors_doc' '--allow=clippy::missing_const_for_fn' '--allow=clippy::inefficient_to_string' '--allow=clippy::ignored_unit_patterns' '--allow=clippy::if_not_else' '--allow=clippy::doc_markdown' '--allow=clippy::derive_partial_eq_without_eq' '--allow=clippy::cast_precision_loss' '--allow=clippy::cast_lossless' '--allow=clippy::assigning_clones' '--allow=clippy::approx_constant' --extern base64=/home/runner/work/lino-objects-codec/lino-objects-codec/rust/target/debug/deps/libbase64-62024e2fc86e6def.rlib --extern links_notation=/home/runner/work/lino-objects-codec/lino-objects-codec/rust/target/debug/deps/liblinks_notation-6442fd1e4c838579.rlib --extern lino_objects_codec=/home/runner/work/lino-objects-codec/lino-objects-codec/rust/target/debug/deps/liblino_objects_codec-08c4ff317c658dd0.rlib -C embed-bitcode=no --check-cfg 'cfg(docsrs,test)' --check-cfg 'cfg(feature, values())' --error-format human`
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:04.2233938Z 
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:04.2234457Z running 5 tests
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:04.3652858Z test src/lib.rs - format::format_indented (line 1043) ... ok
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:04.3732734Z test src/lib.rs - decode (line 887) ... ok
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:04.3819647Z test src/lib.rs - (line 19) ... ok
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:04.3853047Z test src/lib.rs - encode (line 858) ... ok
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:04.4506834Z test src/lib.rs - format::parse_indented (line 1139) ... ok
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:04.4507171Z 
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:04.4507413Z test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.23s
+Test (Rust on ubuntu-latest)	Run tests	2026-01-08T18:49:04.4507761Z 
+Test (Rust on ubuntu-latest)	Run doc tests	﻿2026-01-08T18:49:04.4591023Z ##[group]Run cargo test --doc --verbose
+Test (Rust on ubuntu-latest)	Run doc tests	2026-01-08T18:49:04.4591371Z [36;1mcargo test --doc --verbose[0m
+Test (Rust on ubuntu-latest)	Run doc tests	2026-01-08T18:49:04.4622931Z shell: /usr/bin/bash -e {0}
+Test (Rust on ubuntu-latest)	Run doc tests	2026-01-08T18:49:04.4623165Z env:
+Test (Rust on ubuntu-latest)	Run doc tests	2026-01-08T18:49:04.4623356Z   CARGO_TERM_COLOR: always
+Test (Rust on ubuntu-latest)	Run doc tests	2026-01-08T18:49:04.4623586Z   RUSTFLAGS: -Dwarnings
+Test (Rust on ubuntu-latest)	Run doc tests	2026-01-08T18:49:04.4623799Z   CARGO_HOME: /home/runner/.cargo
+Test (Rust on ubuntu-latest)	Run doc tests	2026-01-08T18:49:04.4624039Z   CARGO_INCREMENTAL: 0
+Test (Rust on ubuntu-latest)	Run doc tests	2026-01-08T18:49:04.4624246Z ##[endgroup]
+Test (Rust on ubuntu-latest)	Run doc tests	2026-01-08T18:49:04.5247831Z [1m[92m       Fresh[0m memchr v2.7.6
+Test (Rust on ubuntu-latest)	Run doc tests	2026-01-08T18:49:04.5248631Z [1m[92m       Fresh[0m nom v8.0.0
+Test (Rust on ubuntu-latest)	Run doc tests	2026-01-08T18:49:04.5249305Z [1m[92m       Fresh[0m links-notation v0.13.0
+Test (Rust on ubuntu-latest)	Run doc tests	2026-01-08T18:49:04.5249915Z [1m[92m       Fresh[0m base64 v0.22.1
+Test (Rust on ubuntu-latest)	Run doc tests	2026-01-08T18:49:04.5250844Z [1m[92m       Fresh[0m lino-objects-codec v0.2.0 (/home/runner/work/lino-objects-codec/lino-objects-codec/rust)
+Test (Rust on ubuntu-latest)	Run doc tests	2026-01-08T18:49:04.5252145Z [1m[92m    Finished[0m `test` profile [unoptimized + debuginfo] target(s) in 0.01s
+Test (Rust on ubuntu-latest)	Run doc tests	2026-01-08T18:49:04.5253248Z [1m[92m   Doc-tests[0m lino_objects_codec
+Test (Rust on ubuntu-latest)	Run doc tests	2026-01-08T18:49:04.5263015Z [1m[92m     Running[0m `/home/runner/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustdoc --edition=2021 --crate-type lib --color always --crate-name lino_objects_codec --test src/lib.rs --test-run-directory /home/runner/work/lino-objects-codec/lino-objects-codec/rust -L dependency=/home/runner/work/lino-objects-codec/lino-objects-codec/rust/target/debug/deps -L dependency=/home/runner/work/lino-objects-codec/lino-objects-codec/rust/target/debug/deps '--warn=clippy::pedantic' '--warn=clippy::nursery' '--warn=clippy::all' '--allow=clippy::use_self' '--allow=clippy::unused_self' '--allow=clippy::unreadable_literal' '--allow=clippy::uninlined_format_args' '--allow=clippy::too_many_lines' '--allow=clippy::similar_names' '--allow=clippy::redundant_closure_for_method_calls' '--allow=clippy::redundant_clone' '--allow=clippy::option_if_let_else' '--allow=clippy::must_use_candidate' '--allow=clippy::module_name_repetitions' '--allow=clippy::missing_panics_doc' '--allow=clippy::missing_errors_doc' '--allow=clippy::missing_const_for_fn' '--allow=clippy::inefficient_to_string' '--allow=clippy::ignored_unit_patterns' '--allow=clippy::if_not_else' '--allow=clippy::doc_markdown' '--allow=clippy::derive_partial_eq_without_eq' '--allow=clippy::cast_precision_loss' '--allow=clippy::cast_lossless' '--allow=clippy::assigning_clones' '--allow=clippy::approx_constant' --extern base64=/home/runner/work/lino-objects-codec/lino-objects-codec/rust/target/debug/deps/libbase64-62024e2fc86e6def.rlib --extern links_notation=/home/runner/work/lino-objects-codec/lino-objects-codec/rust/target/debug/deps/liblinks_notation-6442fd1e4c838579.rlib --extern lino_objects_codec=/home/runner/work/lino-objects-codec/lino-objects-codec/rust/target/debug/deps/liblino_objects_codec-08c4ff317c658dd0.rlib -C embed-bitcode=no --check-cfg 'cfg(docsrs,test)' --check-cfg 'cfg(feature, values())' --error-format human`
+Test (Rust on ubuntu-latest)	Run doc tests	2026-01-08T18:49:04.5496958Z 
+Test (Rust on ubuntu-latest)	Run doc tests	2026-01-08T18:49:04.5497483Z running 5 tests
+Test (Rust on ubuntu-latest)	Run doc tests	2026-01-08T18:49:04.6732822Z test src/lib.rs - format::format_indented (line 1043) ... ok
+Test (Rust on ubuntu-latest)	Run doc tests	2026-01-08T18:49:04.6734206Z test src/lib.rs - decode (line 887) ... ok
+Test (Rust on ubuntu-latest)	Run doc tests	2026-01-08T18:49:04.6888593Z test src/lib.rs - (line 19) ... ok
+Test (Rust on ubuntu-latest)	Run doc tests	2026-01-08T18:49:04.6889201Z test src/lib.rs - encode (line 858) ... ok
+Test (Rust on ubuntu-latest)	Run doc tests	2026-01-08T18:49:04.7599487Z test src/lib.rs - format::parse_indented (line 1139) ... ok
+Test (Rust on ubuntu-latest)	Run doc tests	2026-01-08T18:49:04.7599990Z 
+Test (Rust on ubuntu-latest)	Run doc tests	2026-01-08T18:49:04.7600393Z test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.21s
+Test (Rust on ubuntu-latest)	Run doc tests	2026-01-08T18:49:04.7601017Z 
+Test (Rust on ubuntu-latest)	Run example	﻿2026-01-08T18:49:04.7683059Z ##[group]Run cargo run --example basic_usage
+Test (Rust on ubuntu-latest)	Run example	2026-01-08T18:49:04.7683417Z [36;1mcargo run --example basic_usage[0m
+Test (Rust on ubuntu-latest)	Run example	2026-01-08T18:49:04.7715352Z shell: /usr/bin/bash -e {0}
+Test (Rust on ubuntu-latest)	Run example	2026-01-08T18:49:04.7715593Z env:
+Test (Rust on ubuntu-latest)	Run example	2026-01-08T18:49:04.7715777Z   CARGO_TERM_COLOR: always
+Test (Rust on ubuntu-latest)	Run example	2026-01-08T18:49:04.7716009Z   RUSTFLAGS: -Dwarnings
+Test (Rust on ubuntu-latest)	Run example	2026-01-08T18:49:04.7716228Z   CARGO_HOME: /home/runner/.cargo
+Test (Rust on ubuntu-latest)	Run example	2026-01-08T18:49:04.7716468Z   CARGO_INCREMENTAL: 0
+Test (Rust on ubuntu-latest)	Run example	2026-01-08T18:49:04.7716666Z ##[endgroup]
+Test (Rust on ubuntu-latest)	Run example	2026-01-08T18:49:04.8352140Z [1m[92m    Finished[0m `dev` profile [unoptimized + debuginfo] target(s) in 0.01s
+Test (Rust on ubuntu-latest)	Run example	2026-01-08T18:49:04.8355503Z [1m[92m     Running[0m `target/debug/examples/basic_usage`
+Test (Rust on ubuntu-latest)	Run example	2026-01-08T18:49:04.8372069Z === Links Notation Objects Codec - Rust Example ===
+Test (Rust on ubuntu-latest)	Run example	2026-01-08T18:49:04.8372441Z 
+Test (Rust on ubuntu-latest)	Run example	2026-01-08T18:49:04.8372520Z 1. Basic Types:
+Test (Rust on ubuntu-latest)	Run example	2026-01-08T18:49:04.8372891Z    Null: (null) -> decoded: Null
+Test (Rust on ubuntu-latest)	Run example	2026-01-08T18:49:04.8373257Z    true: (bool true) -> decoded: Bool(true)
+Test (Rust on ubuntu-latest)	Run example	2026-01-08T18:49:04.8373691Z    42: (int 42) -> decoded: Int(42)
+Test (Rust on ubuntu-latest)	Run example	2026-01-08T18:49:04.8374166Z    3.14159: (float 3.14159) -> decoded: Float(3.14159)
+Test (Rust on ubuntu-latest)	Run example	2026-01-08T18:49:04.8374656Z    Infinity: (float Infinity) -> decoded: Float(inf)
+Test (Rust on ubuntu-latest)	Run example	2026-01-08T18:49:04.8375243Z    NaN: (float NaN) -> decoded is_nan: true
+Test (Rust on ubuntu-latest)	Run example	2026-01-08T18:49:04.8375814Z    'Hello, World!': (str SGVsbG8sIFdvcmxkIQ==) -> decoded: String("Hello, World!")
+Test (Rust on ubuntu-latest)	Run example	2026-01-08T18:49:04.8376556Z    Unicode: (str 5L2g5aW95LiW55WMIPCfjI0=) -> decoded: String("你好世界 🌍")
+Test (Rust on ubuntu-latest)	Run example	2026-01-08T18:49:04.8376974Z 
+Test (Rust on ubuntu-latest)	Run example	2026-01-08T18:49:04.8377075Z 2. Collections:
+Test (Rust on ubuntu-latest)	Run example	2026-01-08T18:49:04.8377302Z    Array [1, 2, 3]: (array (int 1) (int 2) (int 3))
+Test (Rust on ubuntu-latest)	Run example	2026-01-08T18:49:04.8377588Z    Decoded: Array([Int(1), Int(2), Int(3)])
+Test (Rust on ubuntu-latest)	Run example	2026-01-08T18:49:04.8379275Z    Object {name, age, active}: (object ((str bmFtZQ==) (str QWxpY2U=)) ((str YWdl) (int 30)) ((str YWN0aXZl) (bool true)))
+Test (Rust on ubuntu-latest)	Run example	2026-01-08T18:49:04.8380455Z    Decoded: Object([("name", String("Alice")), ("age", Int(30)), ("active", Bool(true))])
+Test (Rust on ubuntu-latest)	Run example	2026-01-08T18:49:04.8381060Z 
+Test (Rust on ubuntu-latest)	Run example	2026-01-08T18:49:04.8381194Z 3. Nested Structure:
+Test (Rust on ubuntu-latest)	Run example	2026-01-08T18:49:04.8383121Z    Encoded: (object ((str aWQ=) (int 123)) ((str bmFtZQ==) (str VGVzdCBPYmplY3Q=)) ((str dGFncw==) (array (str dGFnMQ==) (str dGFnMg==))) ((str bWV0YWRhdGE=) (object ((str dmVyc2lvbg==) (int 1)) ((str Y3JlYXRlZA==) (str MjAyNS0wMS0wMQ==)))))
+Test (Rust on ubuntu-latest)	Run example	2026-01-08T18:49:04.8385157Z    Decoded name: Some(String("Test Object"))
+Test (Rust on ubuntu-latest)	Run example	2026-01-08T18:49:04.8385782Z    Decoded tags: Some(Array([String("tag1"), String("tag2")]))
+Test (Rust on ubuntu-latest)	Run example	2026-01-08T18:49:04.8386380Z    Decoded metadata.version: Some(Int(1))
+Test (Rust on ubuntu-latest)	Run example	2026-01-08T18:49:04.8386705Z 
+Test (Rust on ubuntu-latest)	Run example	2026-01-08T18:49:04.8386846Z 4. Mixed Type Array:
+Test (Rust on ubuntu-latest)	Run example	2026-01-08T18:49:04.8389050Z    Encoded: (array (int 1) (str aGVsbG8=) (bool true) (null) (float 2.5))
+Test (Rust on ubuntu-latest)	Run example	2026-01-08T18:49:04.8389534Z    Decoded: Array([Int(1), String("hello"), Bool(true), Null, Float(2.5)])
+Test (Rust on ubuntu-latest)	Run example	2026-01-08T18:49:04.8389815Z 
+Test (Rust on ubuntu-latest)	Run example	2026-01-08T18:49:04.8389912Z 5. Roundtrip Verification:
+Test (Rust on ubuntu-latest)	Run example	2026-01-08T18:49:04.8390142Z    Original == Decoded: true
+Test (Rust on ubuntu-latest)	Run example	2026-01-08T18:49:04.8390522Z 
+Test (Rust on ubuntu-latest)	Run example	2026-01-08T18:49:04.8390618Z === Example completed successfully! ===
+Test (Rust on ubuntu-latest)	Post Cache cargo dependencies	﻿2026-01-08T18:49:04.9008780Z Post job cleanup.
+Test (Rust on ubuntu-latest)	Post Cache cargo dependencies	2026-01-08T18:49:05.0287455Z Cache hit occurred on the primary key Linux-cargo-3bdf1052f98aec50857f27e3615100242b9f9c1f98c417d8384cf7fd70b81aba, not saving cache.
+Test (Rust on ubuntu-latest)	Post Run actions/checkout@v4	﻿2026-01-08T18:49:05.0394569Z Post job cleanup.
+Test (Rust on ubuntu-latest)	Post Run actions/checkout@v4	2026-01-08T18:49:05.1334183Z [command]/usr/bin/git version
+Test (Rust on ubuntu-latest)	Post Run actions/checkout@v4	2026-01-08T18:49:05.1378277Z git version 2.52.0
+Test (Rust on ubuntu-latest)	Post Run actions/checkout@v4	2026-01-08T18:49:05.1435826Z Temporarily overriding HOME='/home/runner/work/_temp/42ebefad-6d99-456b-8398-07a4e493362a' before making global git config changes
+Test (Rust on ubuntu-latest)	Post Run actions/checkout@v4	2026-01-08T18:49:05.1437180Z Adding repository directory to the temporary git global config as a safe directory
+Test (Rust on ubuntu-latest)	Post Run actions/checkout@v4	2026-01-08T18:49:05.1442215Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/lino-objects-codec/lino-objects-codec
+Test (Rust on ubuntu-latest)	Post Run actions/checkout@v4	2026-01-08T18:49:05.1477759Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+Test (Rust on ubuntu-latest)	Post Run actions/checkout@v4	2026-01-08T18:49:05.1510481Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+Test (Rust on ubuntu-latest)	Post Run actions/checkout@v4	2026-01-08T18:49:05.1759135Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Test (Rust on ubuntu-latest)	Post Run actions/checkout@v4	2026-01-08T18:49:05.1770867Z http.https://github.com/.extraheader
+Test (Rust on ubuntu-latest)	Post Run actions/checkout@v4	2026-01-08T18:49:05.1784254Z [command]/usr/bin/git config --local --unset-all http.https://github.com/.extraheader
+Test (Rust on ubuntu-latest)	Post Run actions/checkout@v4	2026-01-08T18:49:05.1815944Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+Test (Rust on ubuntu-latest)	Post Run actions/checkout@v4	2026-01-08T18:49:05.2039411Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+Test (Rust on ubuntu-latest)	Post Run actions/checkout@v4	2026-01-08T18:49:05.2070316Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+Test (Rust on ubuntu-latest)	Complete job	﻿2026-01-08T18:49:05.2393094Z Cleaning up orphan processes
+Build Package	Set up job	﻿2026-01-08T18:49:46.7644376Z Current runner version: '2.330.0'
+Build Package	Set up job	2026-01-08T18:49:46.7672607Z ##[group]Runner Image Provisioner
+Build Package	Set up job	2026-01-08T18:49:46.7673466Z Hosted Compute Agent
+Build Package	Set up job	2026-01-08T18:49:46.7674134Z Version: 20251211.462
+Build Package	Set up job	2026-01-08T18:49:46.7674740Z Commit: 6cbad8c2bb55d58165063d031ccabf57e2d2db61
+Build Package	Set up job	2026-01-08T18:49:46.7675458Z Build Date: 2025-12-11T16:28:49Z
+Build Package	Set up job	2026-01-08T18:49:46.7676096Z Worker ID: {3151c4da-211d-4be8-a34a-4efc4c02a290}
+Build Package	Set up job	2026-01-08T18:49:46.7676925Z ##[endgroup]
+Build Package	Set up job	2026-01-08T18:49:46.7677435Z ##[group]Operating System
+Build Package	Set up job	2026-01-08T18:49:46.7678054Z Ubuntu
+Build Package	Set up job	2026-01-08T18:49:46.7678629Z 24.04.3
+Build Package	Set up job	2026-01-08T18:49:46.7679077Z LTS
+Build Package	Set up job	2026-01-08T18:49:46.7679743Z ##[endgroup]
+Build Package	Set up job	2026-01-08T18:49:46.7680325Z ##[group]Runner Image
+Build Package	Set up job	2026-01-08T18:49:46.7680890Z Image: ubuntu-24.04
+Build Package	Set up job	2026-01-08T18:49:46.7681389Z Version: 20260105.202.1
+Build Package	Set up job	2026-01-08T18:49:46.7682486Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20260105.202/images/ubuntu/Ubuntu2404-Readme.md
+Build Package	Set up job	2026-01-08T18:49:46.7683785Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20260105.202
+Build Package	Set up job	2026-01-08T18:49:46.7685129Z ##[endgroup]
+Build Package	Set up job	2026-01-08T18:49:46.7687625Z ##[group]GITHUB_TOKEN Permissions
+Build Package	Set up job	2026-01-08T18:49:46.7690958Z Actions: write
+Build Package	Set up job	2026-01-08T18:49:46.7691522Z ArtifactMetadata: write
+Build Package	Set up job	2026-01-08T18:49:46.7692088Z Attestations: write
+Build Package	Set up job	2026-01-08T18:49:46.7692740Z Checks: write
+Build Package	Set up job	2026-01-08T18:49:46.7693273Z Contents: write
+Build Package	Set up job	2026-01-08T18:49:46.7693820Z Deployments: write
+Build Package	Set up job	2026-01-08T18:49:46.7694872Z Discussions: write
+Build Package	Set up job	2026-01-08T18:49:46.7695624Z Issues: write
+Build Package	Set up job	2026-01-08T18:49:46.7696249Z Metadata: read
+Build Package	Set up job	2026-01-08T18:49:46.7697092Z Models: read
+Build Package	Set up job	2026-01-08T18:49:46.7697749Z Packages: write
+Build Package	Set up job	2026-01-08T18:49:46.7698414Z Pages: write
+Build Package	Set up job	2026-01-08T18:49:46.7699010Z PullRequests: write
+Build Package	Set up job	2026-01-08T18:49:46.7699814Z RepositoryProjects: write
+Build Package	Set up job	2026-01-08T18:49:46.7700402Z SecurityEvents: write
+Build Package	Set up job	2026-01-08T18:49:46.7700991Z Statuses: write
+Build Package	Set up job	2026-01-08T18:49:46.7701522Z ##[endgroup]
+Build Package	Set up job	2026-01-08T18:49:46.7704161Z Secret source: Actions
+Build Package	Set up job	2026-01-08T18:49:46.7705413Z Prepare workflow directory
+Build Package	Set up job	2026-01-08T18:49:46.8078627Z Prepare all required actions
+Build Package	Set up job	2026-01-08T18:49:46.8116655Z Getting action download info
+Build Package	Set up job	2026-01-08T18:49:47.1866725Z Download action repository 'actions/checkout@v4' (SHA:34e114876b0b11c390a56381ad16ebd13914f8d5)
+Build Package	Set up job	2026-01-08T18:49:47.2884043Z Download action repository 'dtolnay/rust-toolchain@stable' (SHA:4be9e76fd7c4901c61fb841f559994984270fce7)
+Build Package	Set up job	2026-01-08T18:49:47.4646254Z Download action repository 'actions/cache@v4' (SHA:0057852bfaa89a56745cba8c7296529d2fc39830)
+Build Package	Set up job	2026-01-08T18:49:47.7680130Z Complete job name: Build Package
+Build Package	Run actions/checkout@v4	﻿2026-01-08T18:49:47.8457341Z ##[group]Run actions/checkout@v4
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:47.8458542Z with:
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:47.8459548Z   repository: link-foundation/lino-objects-codec
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:47.8460864Z   token: ***
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:47.8461542Z   ssh-strict: true
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:47.8462255Z   ssh-user: git
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:47.8462979Z   persist-credentials: true
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:47.8463799Z   clean: true
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:47.8464551Z   sparse-checkout-cone-mode: true
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:47.8465448Z   fetch-depth: 1
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:47.8466149Z   fetch-tags: false
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:47.8466891Z   show-progress: true
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:47.8467626Z   lfs: false
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:47.8468301Z   submodules: false
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:47.8469066Z   set-safe-directory: true
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:47.8470203Z env:
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:47.8470886Z   CARGO_TERM_COLOR: always
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:47.8471703Z   RUSTFLAGS: -Dwarnings
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:47.8472473Z ##[endgroup]
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:47.9562228Z Syncing repository: link-foundation/lino-objects-codec
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:47.9566579Z ##[group]Getting Git version info
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:47.9568935Z Working directory is '/home/runner/work/lino-objects-codec/lino-objects-codec'
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:47.9571272Z [command]/usr/bin/git version
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:47.9624542Z git version 2.52.0
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:47.9649181Z ##[endgroup]
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:47.9663768Z Temporarily overriding HOME='/home/runner/work/_temp/c3efa1f8-02d6-43ea-8f35-977a123f7f67' before making global git config changes
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:47.9668807Z Adding repository directory to the temporary git global config as a safe directory
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:47.9671299Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/lino-objects-codec/lino-objects-codec
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:47.9709148Z Deleting the contents of '/home/runner/work/lino-objects-codec/lino-objects-codec'
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:47.9712447Z ##[group]Initializing the repository
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:47.9716869Z [command]/usr/bin/git init /home/runner/work/lino-objects-codec/lino-objects-codec
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:47.9805574Z hint: Using 'master' as the name for the initial branch. This default branch name
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:47.9807716Z hint: will change to "main" in Git 3.0. To configure the initial branch name
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:47.9810212Z hint: to use in all of your new repositories, which will suppress this warning,
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:47.9812326Z hint: call:
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:47.9813355Z hint:
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:47.9814675Z hint: 	git config --global init.defaultBranch <name>
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:47.9816386Z hint:
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:47.9817934Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:47.9820809Z hint: 'development'. The just-created branch can be renamed via this command:
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:47.9822957Z hint:
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:47.9824053Z hint: 	git branch -m <name>
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:47.9825263Z hint:
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:47.9826899Z hint: Disable this message with "git config set advice.defaultBranchName false"
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:47.9830044Z Initialized empty Git repository in /home/runner/work/lino-objects-codec/lino-objects-codec/.git/
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:47.9833344Z [command]/usr/bin/git remote add origin https://github.com/link-foundation/lino-objects-codec
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:47.9860605Z ##[endgroup]
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:47.9862043Z ##[group]Disabling automatic garbage collection
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:47.9864899Z [command]/usr/bin/git config --local gc.auto 0
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:47.9896193Z ##[endgroup]
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:47.9897401Z ##[group]Setting up auth
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:47.9902735Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:47.9934297Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:48.0264369Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:48.0297110Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:48.0526796Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:48.0567698Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:48.0803612Z [command]/usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:48.0838222Z ##[endgroup]
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:48.0839732Z ##[group]Fetching the repository
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:48.0847445Z [command]/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +c79c77d68a90cadbd439c9613a7050501095c92d:refs/remotes/origin/main
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:48.3135719Z From https://github.com/link-foundation/lino-objects-codec
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:48.3137479Z  * [new ref]         c79c77d68a90cadbd439c9613a7050501095c92d -> origin/main
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:48.3169947Z ##[endgroup]
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:48.3171324Z ##[group]Determining the checkout info
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:48.3172717Z ##[endgroup]
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:48.3178286Z [command]/usr/bin/git sparse-checkout disable
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:48.3222224Z [command]/usr/bin/git config --local --unset-all extensions.worktreeConfig
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:48.3250761Z ##[group]Checking out the ref
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:48.3254359Z [command]/usr/bin/git checkout --progress --force -B main refs/remotes/origin/main
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:48.3381480Z Switched to a new branch 'main'
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:48.3384727Z branch 'main' set up to track 'origin/main'.
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:48.3393248Z ##[endgroup]
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:48.3430303Z [command]/usr/bin/git log -1 --format=%H
+Build Package	Run actions/checkout@v4	2026-01-08T18:49:48.3457570Z c79c77d68a90cadbd439c9613a7050501095c92d
+Build Package	Set up Rust	﻿2026-01-08T18:49:48.3949500Z ##[group]Run dtolnay/rust-toolchain@stable
+Build Package	Set up Rust	2026-01-08T18:49:48.3950536Z with:
+Build Package	Set up Rust	2026-01-08T18:49:48.3951201Z   toolchain: stable
+Build Package	Set up Rust	2026-01-08T18:49:48.3951919Z env:
+Build Package	Set up Rust	2026-01-08T18:49:48.3952573Z   CARGO_TERM_COLOR: always
+Build Package	Set up Rust	2026-01-08T18:49:48.3953402Z   RUSTFLAGS: -Dwarnings
+Build Package	Set up Rust	2026-01-08T18:49:48.3954171Z ##[endgroup]
+Build Package	Set up Rust	2026-01-08T18:49:48.4094281Z ##[group]Run : parse toolchain version
+Build Package	Set up Rust	2026-01-08T18:49:48.4095436Z [36;1m: parse toolchain version[0m
+Build Package	Set up Rust	2026-01-08T18:49:48.4096399Z [36;1mif [[ -z $toolchain ]]; then[0m
+Build Package	Set up Rust	2026-01-08T18:49:48.4098064Z [36;1m  # GitHub does not enforce `required: true` inputs itself. https://github.com/actions/runner/issues/1070[0m
+Build Package	Set up Rust	2026-01-08T18:49:48.4100022Z [36;1m  echo "'toolchain' is a required input" >&2[0m
+Build Package	Set up Rust	2026-01-08T18:49:48.4101043Z [36;1m  exit 1[0m
+Build Package	Set up Rust	2026-01-08T18:49:48.4102144Z [36;1melif [[ $toolchain =~ ^stable' '[0-9]+' '(year|month|week|day)s?' 'ago$ ]]; then[0m
+Build Package	Set up Rust	2026-01-08T18:49:48.4103502Z [36;1m  if [[ Linux == macOS ]]; then[0m
+Build Package	Set up Rust	2026-01-08T18:49:48.4105196Z [36;1m    echo "toolchain=1.$((($(date -v-$(sed 's/stable \([0-9]*\) \(.\).*/\1\2/' <<< $toolchain) +%s)/60/60/24-16569)/7/6))" >> $GITHUB_OUTPUT[0m
+Build Package	Set up Rust	2026-01-08T18:49:48.4106925Z [36;1m  else[0m
+Build Package	Set up Rust	2026-01-08T18:49:48.4108242Z [36;1m    echo "toolchain=1.$((($(date --date "${toolchain#stable }" +%s)/60/60/24-16569)/7/6))" >> $GITHUB_OUTPUT[0m
+Build Package	Set up Rust	2026-01-08T18:49:48.4109855Z [36;1m  fi[0m
+Build Package	Set up Rust	2026-01-08T18:49:48.4110844Z [36;1melif [[ $toolchain =~ ^stable' 'minus' '[0-9]+' 'releases?$ ]]; then[0m
+Build Package	Set up Rust	2026-01-08T18:49:48.4112581Z [36;1m  echo "toolchain=1.$((($(date +%s)/60/60/24-16569)/7/6-${toolchain//[^0-9]/}))" >> $GITHUB_OUTPUT[0m
+Build Package	Set up Rust	2026-01-08T18:49:48.4114134Z [36;1melif [[ $toolchain =~ ^1\.[0-9]+$ ]]; then[0m
+Build Package	Set up Rust	2026-01-08T18:49:48.4115855Z [36;1m  echo "toolchain=1.$((i=${toolchain#1.}, c=($(date +%s)/60/60/24-16569)/7/6, i+9*i*(10*i<=c)+90*i*(100*i<=c)))" >> $GITHUB_OUTPUT[0m
+Build Package	Set up Rust	2026-01-08T18:49:48.4117497Z [36;1melse[0m
+Build Package	Set up Rust	2026-01-08T18:49:48.4118313Z [36;1m  echo "toolchain=$toolchain" >> $GITHUB_OUTPUT[0m
+Build Package	Set up Rust	2026-01-08T18:49:48.4119500Z [36;1mfi[0m
+Build Package	Set up Rust	2026-01-08T18:49:48.4161411Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Build Package	Set up Rust	2026-01-08T18:49:48.4162551Z env:
+Build Package	Set up Rust	2026-01-08T18:49:48.4163207Z   CARGO_TERM_COLOR: always
+Build Package	Set up Rust	2026-01-08T18:49:48.4164012Z   RUSTFLAGS: -Dwarnings
+Build Package	Set up Rust	2026-01-08T18:49:48.4164770Z   toolchain: stable
+Build Package	Set up Rust	2026-01-08T18:49:48.4165470Z ##[endgroup]
+Build Package	Set up Rust	2026-01-08T18:49:48.4410763Z ##[group]Run : construct rustup command line
+Build Package	Set up Rust	2026-01-08T18:49:48.4411871Z [36;1m: construct rustup command line[0m
+Build Package	Set up Rust	2026-01-08T18:49:48.4413310Z [36;1mecho "targets=$(for t in ${targets//,/ }; do echo -n ' --target' $t; done)" >> $GITHUB_OUTPUT[0m
+Build Package	Set up Rust	2026-01-08T18:49:48.4415338Z [36;1mecho "components=$(for c in ${components//,/ }; do echo -n ' --component' $c; done)" >> $GITHUB_OUTPUT[0m
+Build Package	Set up Rust	2026-01-08T18:49:48.4416956Z [36;1mecho "downgrade=" >> $GITHUB_OUTPUT[0m
+Build Package	Set up Rust	2026-01-08T18:49:48.4451083Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Build Package	Set up Rust	2026-01-08T18:49:48.4452202Z env:
+Build Package	Set up Rust	2026-01-08T18:49:48.4452869Z   CARGO_TERM_COLOR: always
+Build Package	Set up Rust	2026-01-08T18:49:48.4453692Z   RUSTFLAGS: -Dwarnings
+Build Package	Set up Rust	2026-01-08T18:49:48.4454436Z   targets: 
+Build Package	Set up Rust	2026-01-08T18:49:48.4455091Z   components: 
+Build Package	Set up Rust	2026-01-08T18:49:48.4455757Z ##[endgroup]
+Build Package	Set up Rust	2026-01-08T18:49:48.4567664Z ##[group]Run : set $CARGO_HOME
+Build Package	Set up Rust	2026-01-08T18:49:48.4568533Z [36;1m: set $CARGO_HOME[0m
+Build Package	Set up Rust	2026-01-08T18:49:48.4569782Z [36;1mecho CARGO_HOME=${CARGO_HOME:-"$HOME/.cargo"} >> $GITHUB_ENV[0m
+Build Package	Set up Rust	2026-01-08T18:49:48.4602799Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Build Package	Set up Rust	2026-01-08T18:49:48.4603880Z env:
+Build Package	Set up Rust	2026-01-08T18:49:48.4604709Z   CARGO_TERM_COLOR: always
+Build Package	Set up Rust	2026-01-08T18:49:48.4605524Z   RUSTFLAGS: -Dwarnings
+Build Package	Set up Rust	2026-01-08T18:49:48.4606334Z ##[endgroup]
+Build Package	Set up Rust	2026-01-08T18:49:48.4715887Z ##[group]Run : install rustup if needed
+Build Package	Set up Rust	2026-01-08T18:49:48.4716883Z [36;1m: install rustup if needed[0m
+Build Package	Set up Rust	2026-01-08T18:49:48.4717861Z [36;1mif ! command -v rustup &>/dev/null; then[0m
+Build Package	Set up Rust	2026-01-08T18:49:48.4720357Z [36;1m  curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused --location --silent --show-error --fail https://sh.rustup.rs | sh -s -- --default-toolchain none -y[0m
+Build Package	Set up Rust	2026-01-08T18:49:48.4722932Z [36;1m  echo "$CARGO_HOME/bin" >> $GITHUB_PATH[0m
+Build Package	Set up Rust	2026-01-08T18:49:48.4723879Z [36;1mfi[0m
+Build Package	Set up Rust	2026-01-08T18:49:48.4756980Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Build Package	Set up Rust	2026-01-08T18:49:48.4758087Z env:
+Build Package	Set up Rust	2026-01-08T18:49:48.4758739Z   CARGO_TERM_COLOR: always
+Build Package	Set up Rust	2026-01-08T18:49:48.4759752Z   RUSTFLAGS: -Dwarnings
+Build Package	Set up Rust	2026-01-08T18:49:48.4760549Z   CARGO_HOME: /home/runner/.cargo
+Build Package	Set up Rust	2026-01-08T18:49:48.4761386Z ##[endgroup]
+Build Package	Set up Rust	2026-01-08T18:49:48.4876693Z ##[group]Run rustup toolchain install stable --profile minimal --no-self-update
+Build Package	Set up Rust	2026-01-08T18:49:48.4878421Z [36;1mrustup toolchain install stable --profile minimal --no-self-update[0m
+Build Package	Set up Rust	2026-01-08T18:49:48.4912171Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Build Package	Set up Rust	2026-01-08T18:49:48.4913259Z env:
+Build Package	Set up Rust	2026-01-08T18:49:48.4913910Z   CARGO_TERM_COLOR: always
+Build Package	Set up Rust	2026-01-08T18:49:48.4914693Z   RUSTFLAGS: -Dwarnings
+Build Package	Set up Rust	2026-01-08T18:49:48.4915474Z   CARGO_HOME: /home/runner/.cargo
+Build Package	Set up Rust	2026-01-08T18:49:48.4916364Z   RUSTUP_PERMIT_COPY_RENAME: 1
+Build Package	Set up Rust	2026-01-08T18:49:48.4917173Z ##[endgroup]
+Build Package	Set up Rust	2026-01-08T18:49:49.9240604Z info: syncing channel updates for 'stable-x86_64-unknown-linux-gnu'
+Build Package	Set up Rust	2026-01-08T18:49:50.0154175Z 
+Build Package	Set up Rust	2026-01-08T18:49:50.0258558Z   stable-x86_64-unknown-linux-gnu unchanged - rustc 1.92.0 (ded5c06cf 2025-12-08)
+Build Package	Set up Rust	2026-01-08T18:49:50.0259194Z 
+Build Package	Set up Rust	2026-01-08T18:49:50.0320196Z ##[group]Run rustup default stable
+Build Package	Set up Rust	2026-01-08T18:49:50.0320554Z [36;1mrustup default stable[0m
+Build Package	Set up Rust	2026-01-08T18:49:50.0358547Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Build Package	Set up Rust	2026-01-08T18:49:50.0358936Z env:
+Build Package	Set up Rust	2026-01-08T18:49:50.0359178Z   CARGO_TERM_COLOR: always
+Build Package	Set up Rust	2026-01-08T18:49:50.0359775Z   RUSTFLAGS: -Dwarnings
+Build Package	Set up Rust	2026-01-08T18:49:50.0360042Z   CARGO_HOME: /home/runner/.cargo
+Build Package	Set up Rust	2026-01-08T18:49:50.0360315Z ##[endgroup]
+Build Package	Set up Rust	2026-01-08T18:49:50.0474311Z info: using existing install for 'stable-x86_64-unknown-linux-gnu'
+Build Package	Set up Rust	2026-01-08T18:49:50.0882300Z info: default toolchain set to 'stable-x86_64-unknown-linux-gnu'
+Build Package	Set up Rust	2026-01-08T18:49:50.0882917Z 
+Build Package	Set up Rust	2026-01-08T18:49:50.0982423Z   stable-x86_64-unknown-linux-gnu unchanged - rustc 1.92.0 (ded5c06cf 2025-12-08)
+Build Package	Set up Rust	2026-01-08T18:49:50.0983038Z 
+Build Package	Set up Rust	2026-01-08T18:49:50.1035774Z ##[group]Run : create cachekey
+Build Package	Set up Rust	2026-01-08T18:49:50.1036111Z [36;1m: create cachekey[0m
+Build Package	Set up Rust	2026-01-08T18:49:50.1036648Z [36;1mDATE=$(rustc +stable --version --verbose | sed -ne 's/^commit-date: \(20[0-9][0-9]\)-\([01][0-9]\)-\([0-3][0-9]\)$/\1\2\3/p')[0m
+Build Package	Set up Rust	2026-01-08T18:49:50.1037329Z [36;1mHASH=$(rustc +stable --version --verbose | sed -ne 's/^commit-hash: //p')[0m
+Build Package	Set up Rust	2026-01-08T18:49:50.1037886Z [36;1mecho "cachekey=$(echo $DATE$HASH | head -c12)" >> $GITHUB_OUTPUT[0m
+Build Package	Set up Rust	2026-01-08T18:49:50.1075610Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Build Package	Set up Rust	2026-01-08T18:49:50.1075980Z env:
+Build Package	Set up Rust	2026-01-08T18:49:50.1076208Z   CARGO_TERM_COLOR: always
+Build Package	Set up Rust	2026-01-08T18:49:50.1076498Z   RUSTFLAGS: -Dwarnings
+Build Package	Set up Rust	2026-01-08T18:49:50.1076755Z   CARGO_HOME: /home/runner/.cargo
+Build Package	Set up Rust	2026-01-08T18:49:50.1077053Z ##[endgroup]
+Build Package	Set up Rust	2026-01-08T18:49:50.1830942Z ##[group]Run : disable incremental compilation
+Build Package	Set up Rust	2026-01-08T18:49:50.1831408Z [36;1m: disable incremental compilation[0m
+Build Package	Set up Rust	2026-01-08T18:49:50.1831791Z [36;1mif [ -z "${CARGO_INCREMENTAL+set}" ]; then[0m
+Build Package	Set up Rust	2026-01-08T18:49:50.1832154Z [36;1m  echo CARGO_INCREMENTAL=0 >> $GITHUB_ENV[0m
+Build Package	Set up Rust	2026-01-08T18:49:50.1832458Z [36;1mfi[0m
+Build Package	Set up Rust	2026-01-08T18:49:50.1870125Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Build Package	Set up Rust	2026-01-08T18:49:50.1870575Z env:
+Build Package	Set up Rust	2026-01-08T18:49:50.1870809Z   CARGO_TERM_COLOR: always
+Build Package	Set up Rust	2026-01-08T18:49:50.1871356Z   RUSTFLAGS: -Dwarnings
+Build Package	Set up Rust	2026-01-08T18:49:50.1871616Z   CARGO_HOME: /home/runner/.cargo
+Build Package	Set up Rust	2026-01-08T18:49:50.1871896Z ##[endgroup]
+Build Package	Set up Rust	2026-01-08T18:49:50.1952412Z ##[group]Run : enable colors in Cargo output
+Build Package	Set up Rust	2026-01-08T18:49:50.1952785Z [36;1m: enable colors in Cargo output[0m
+Build Package	Set up Rust	2026-01-08T18:49:50.1953114Z [36;1mif [ -z "${CARGO_TERM_COLOR+set}" ]; then[0m
+Build Package	Set up Rust	2026-01-08T18:49:50.1953476Z [36;1m  echo CARGO_TERM_COLOR=always >> $GITHUB_ENV[0m
+Build Package	Set up Rust	2026-01-08T18:49:50.1954049Z [36;1mfi[0m
+Build Package	Set up Rust	2026-01-08T18:49:50.1988363Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Build Package	Set up Rust	2026-01-08T18:49:50.1988740Z env:
+Build Package	Set up Rust	2026-01-08T18:49:50.1988963Z   CARGO_TERM_COLOR: always
+Build Package	Set up Rust	2026-01-08T18:49:50.1989227Z   RUSTFLAGS: -Dwarnings
+Build Package	Set up Rust	2026-01-08T18:49:50.1989798Z   CARGO_HOME: /home/runner/.cargo
+Build Package	Set up Rust	2026-01-08T18:49:50.1990086Z   CARGO_INCREMENTAL: 0
+Build Package	Set up Rust	2026-01-08T18:49:50.1990334Z ##[endgroup]
+Build Package	Set up Rust	2026-01-08T18:49:50.2072658Z ##[group]Run : enable Cargo sparse registry
+Build Package	Set up Rust	2026-01-08T18:49:50.2073037Z [36;1m: enable Cargo sparse registry[0m
+Build Package	Set up Rust	2026-01-08T18:49:50.2073439Z [36;1m# implemented in 1.66, stabilized in 1.68, made default in 1.70[0m
+Build Package	Set up Rust	2026-01-08T18:49:50.2074156Z [36;1mif [ -z "${CARGO_REGISTRIES_CRATES_IO_PROTOCOL+set}" -o -f "/home/runner/work/_temp"/.implicit_cargo_registries_crates_io_protocol ]; then[0m
+Build Package	Set up Rust	2026-01-08T18:49:50.2074881Z [36;1m  if rustc +stable --version --verbose | grep -q '^release: 1\.6[89]\.'; then[0m
+Build Package	Set up Rust	2026-01-08T18:49:50.2075464Z [36;1m    touch "/home/runner/work/_temp"/.implicit_cargo_registries_crates_io_protocol || true[0m
+Build Package	Set up Rust	2026-01-08T18:49:50.2076033Z [36;1m    echo CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse >> $GITHUB_ENV[0m
+Build Package	Set up Rust	2026-01-08T18:49:50.2076559Z [36;1m  elif rustc +stable --version --verbose | grep -q '^release: 1\.6[67]\.'; then[0m
+Build Package	Set up Rust	2026-01-08T18:49:50.2077123Z [36;1m    touch "/home/runner/work/_temp"/.implicit_cargo_registries_crates_io_protocol || true[0m
+Build Package	Set up Rust	2026-01-08T18:49:50.2077651Z [36;1m    echo CARGO_REGISTRIES_CRATES_IO_PROTOCOL=git >> $GITHUB_ENV[0m
+Build Package	Set up Rust	2026-01-08T18:49:50.2078013Z [36;1m  fi[0m
+Build Package	Set up Rust	2026-01-08T18:49:50.2078236Z [36;1mfi[0m
+Build Package	Set up Rust	2026-01-08T18:49:50.2113132Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Build Package	Set up Rust	2026-01-08T18:49:50.2113522Z env:
+Build Package	Set up Rust	2026-01-08T18:49:50.2113761Z   CARGO_TERM_COLOR: always
+Build Package	Set up Rust	2026-01-08T18:49:50.2114026Z   RUSTFLAGS: -Dwarnings
+Build Package	Set up Rust	2026-01-08T18:49:50.2114299Z   CARGO_HOME: /home/runner/.cargo
+Build Package	Set up Rust	2026-01-08T18:49:50.2114584Z   CARGO_INCREMENTAL: 0
+Build Package	Set up Rust	2026-01-08T18:49:50.2114829Z ##[endgroup]
+Build Package	Set up Rust	2026-01-08T18:49:50.2521347Z ##[group]Run : work around spurious network errors in curl 8.0
+Build Package	Set up Rust	2026-01-08T18:49:50.2521861Z [36;1m: work around spurious network errors in curl 8.0[0m
+Build Package	Set up Rust	2026-01-08T18:49:50.2522677Z [36;1m# https://rust-lang.zulipchat.com/#narrow/stream/246057-t-cargo/topic/timeout.20investigation[0m
+Build Package	Set up Rust	2026-01-08T18:49:50.2523349Z [36;1mif rustc +stable --version --verbose | grep -q '^release: 1\.7[01]\.'; then[0m
+Build Package	Set up Rust	2026-01-08T18:49:50.2523851Z [36;1m  echo CARGO_HTTP_MULTIPLEXING=false >> $GITHUB_ENV[0m
+Build Package	Set up Rust	2026-01-08T18:49:50.2524193Z [36;1mfi[0m
+Build Package	Set up Rust	2026-01-08T18:49:50.2563738Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Build Package	Set up Rust	2026-01-08T18:49:50.2564133Z env:
+Build Package	Set up Rust	2026-01-08T18:49:50.2564361Z   CARGO_TERM_COLOR: always
+Build Package	Set up Rust	2026-01-08T18:49:50.2564638Z   RUSTFLAGS: -Dwarnings
+Build Package	Set up Rust	2026-01-08T18:49:50.2564897Z   CARGO_HOME: /home/runner/.cargo
+Build Package	Set up Rust	2026-01-08T18:49:50.2565200Z   CARGO_INCREMENTAL: 0
+Build Package	Set up Rust	2026-01-08T18:49:50.2565438Z ##[endgroup]
+Build Package	Set up Rust	2026-01-08T18:49:50.2808720Z ##[group]Run rustc +stable --version --verbose
+Build Package	Set up Rust	2026-01-08T18:49:50.2809148Z [36;1mrustc +stable --version --verbose[0m
+Build Package	Set up Rust	2026-01-08T18:49:50.2845573Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Build Package	Set up Rust	2026-01-08T18:49:50.2845952Z env:
+Build Package	Set up Rust	2026-01-08T18:49:50.2846189Z   CARGO_TERM_COLOR: always
+Build Package	Set up Rust	2026-01-08T18:49:50.2846451Z   RUSTFLAGS: -Dwarnings
+Build Package	Set up Rust	2026-01-08T18:49:50.2846718Z   CARGO_HOME: /home/runner/.cargo
+Build Package	Set up Rust	2026-01-08T18:49:50.2846996Z   CARGO_INCREMENTAL: 0
+Build Package	Set up Rust	2026-01-08T18:49:50.2847229Z ##[endgroup]
+Build Package	Set up Rust	2026-01-08T18:49:50.3039853Z rustc 1.92.0 (ded5c06cf 2025-12-08)
+Build Package	Set up Rust	2026-01-08T18:49:50.3040909Z binary: rustc
+Build Package	Set up Rust	2026-01-08T18:49:50.3041385Z commit-hash: ded5c06cf21d2b93bffd5d884aa6e96934ee4234
+Build Package	Set up Rust	2026-01-08T18:49:50.3041862Z commit-date: 2025-12-08
+Build Package	Set up Rust	2026-01-08T18:49:50.3042143Z host: x86_64-unknown-linux-gnu
+Build Package	Set up Rust	2026-01-08T18:49:50.3042409Z release: 1.92.0
+Build Package	Set up Rust	2026-01-08T18:49:50.3042859Z LLVM version: 21.1.3
+Build Package	Cache cargo dependencies	﻿2026-01-08T18:49:50.3720435Z ##[group]Run actions/cache@v4
+Build Package	Cache cargo dependencies	2026-01-08T18:49:50.3720781Z with:
+Build Package	Cache cargo dependencies	2026-01-08T18:49:50.3721190Z   path: ~/.cargo/bin/
+Build Package	Cache cargo dependencies	~/.cargo/registry/index/
+Build Package	Cache cargo dependencies	~/.cargo/registry/cache/
+Build Package	Cache cargo dependencies	~/.cargo/git/db/
+Build Package	Cache cargo dependencies	rust/target/
+Build Package	Cache cargo dependencies	
+Build Package	Cache cargo dependencies	2026-01-08T18:49:50.3721885Z   key: Linux-cargo-build-3bdf1052f98aec50857f27e3615100242b9f9c1f98c417d8384cf7fd70b81aba
+Build Package	Cache cargo dependencies	2026-01-08T18:49:50.3722388Z   enableCrossOsArchive: false
+Build Package	Cache cargo dependencies	2026-01-08T18:49:50.3722674Z   fail-on-cache-miss: false
+Build Package	Cache cargo dependencies	2026-01-08T18:49:50.3722927Z   lookup-only: false
+Build Package	Cache cargo dependencies	2026-01-08T18:49:50.3723173Z   save-always: false
+Build Package	Cache cargo dependencies	2026-01-08T18:49:50.3723398Z env:
+Build Package	Cache cargo dependencies	2026-01-08T18:49:50.3723623Z   CARGO_TERM_COLOR: always
+Build Package	Cache cargo dependencies	2026-01-08T18:49:50.3723925Z   RUSTFLAGS: -Dwarnings
+Build Package	Cache cargo dependencies	2026-01-08T18:49:50.3724212Z   CARGO_HOME: /home/runner/.cargo
+Build Package	Cache cargo dependencies	2026-01-08T18:49:50.3724481Z   CARGO_INCREMENTAL: 0
+Build Package	Cache cargo dependencies	2026-01-08T18:49:50.3724728Z ##[endgroup]
+Build Package	Cache cargo dependencies	2026-01-08T18:49:50.6147532Z Cache not found for input keys: Linux-cargo-build-3bdf1052f98aec50857f27e3615100242b9f9c1f98c417d8384cf7fd70b81aba
+Build Package	Build release	﻿2026-01-08T18:49:50.6238835Z ##[group]Run cargo build --release
+Build Package	Build release	2026-01-08T18:49:50.6239161Z [36;1mcargo build --release[0m
+Build Package	Build release	2026-01-08T18:49:50.6279970Z shell: /usr/bin/bash -e {0}
+Build Package	Build release	2026-01-08T18:49:50.6280242Z env:
+Build Package	Build release	2026-01-08T18:49:50.6280435Z   CARGO_TERM_COLOR: always
+Build Package	Build release	2026-01-08T18:49:50.6280678Z   RUSTFLAGS: -Dwarnings
+Build Package	Build release	2026-01-08T18:49:50.6280913Z   CARGO_HOME: /home/runner/.cargo
+Build Package	Build release	2026-01-08T18:49:50.6281167Z   CARGO_INCREMENTAL: 0
+Build Package	Build release	2026-01-08T18:49:50.6281378Z ##[endgroup]
+Build Package	Build release	2026-01-08T18:49:51.6869566Z [1m[92m    Updating[0m crates.io index
+Build Package	Build release	2026-01-08T18:49:52.4356480Z [1m[92m Downloading[0m crates ...
+Build Package	Build release	2026-01-08T18:49:52.5453278Z [1m[92m  Downloaded[0m links-notation v0.13.0
+Build Package	Build release	2026-01-08T18:49:52.5821759Z [1m[92m  Downloaded[0m memchr v2.7.6
+Build Package	Build release	2026-01-08T18:49:52.5878916Z [1m[92m  Downloaded[0m nom v8.0.0
+Build Package	Build release	2026-01-08T18:49:52.5934417Z [1m[92m  Downloaded[0m base64 v0.22.1
+Build Package	Build release	2026-01-08T18:49:52.6291736Z [1m[92m   Compiling[0m memchr v2.7.6
+Build Package	Build release	2026-01-08T18:49:52.6292343Z [1m[92m   Compiling[0m base64 v0.22.1
+Build Package	Build release	2026-01-08T18:49:54.8531029Z [1m[92m   Compiling[0m nom v8.0.0
+Build Package	Build release	2026-01-08T18:49:57.4406517Z [1m[92m   Compiling[0m links-notation v0.13.0
+Build Package	Build release	2026-01-08T18:49:57.8201839Z [1m[92m   Compiling[0m lino-objects-codec v0.2.0 (/home/runner/work/lino-objects-codec/lino-objects-codec/rust)
+Build Package	Build release	2026-01-08T18:49:58.7205131Z [1m[92m    Finished[0m `release` profile [optimized] target(s) in 7.73s
+Build Package	Package crate	﻿2026-01-08T18:49:58.7308011Z ##[group]Run cargo package --list
+Build Package	Package crate	2026-01-08T18:49:58.7308354Z [36;1mcargo package --list[0m
+Build Package	Package crate	2026-01-08T18:49:58.7343833Z shell: /usr/bin/bash -e {0}
+Build Package	Package crate	2026-01-08T18:49:58.7344091Z env:
+Build Package	Package crate	2026-01-08T18:49:58.7344287Z   CARGO_TERM_COLOR: always
+Build Package	Package crate	2026-01-08T18:49:58.7344523Z   RUSTFLAGS: -Dwarnings
+Build Package	Package crate	2026-01-08T18:49:58.7344773Z   CARGO_HOME: /home/runner/.cargo
+Build Package	Package crate	2026-01-08T18:49:58.7345027Z   CARGO_INCREMENTAL: 0
+Build Package	Package crate	2026-01-08T18:49:58.7345232Z ##[endgroup]
+Build Package	Package crate	2026-01-08T18:49:59.0118292Z .cargo_vcs_info.json
+Build Package	Package crate	2026-01-08T18:49:59.0118686Z .gitignore
+Build Package	Package crate	2026-01-08T18:49:59.0118952Z CHANGELOG.md
+Build Package	Package crate	2026-01-08T18:49:59.0119232Z Cargo.lock
+Build Package	Package crate	2026-01-08T18:49:59.0119661Z Cargo.toml
+Build Package	Package crate	2026-01-08T18:49:59.0119882Z Cargo.toml.orig
+Build Package	Package crate	2026-01-08T18:49:59.0120132Z README.md
+Build Package	Package crate	2026-01-08T18:49:59.0120420Z changelog.d/20260108_193000_ci_cd_improvements.md
+Build Package	Package crate	2026-01-08T18:49:59.0120840Z changelog.d/README.md
+Build Package	Package crate	2026-01-08T18:49:59.0121137Z examples/basic_usage.rs
+Build Package	Package crate	2026-01-08T18:49:59.0121432Z scripts/bump-version.mjs
+Build Package	Package crate	2026-01-08T18:49:59.0121773Z scripts/check-changelog-fragment.mjs
+Build Package	Package crate	2026-01-08T18:49:59.0122303Z scripts/check-file-size.mjs
+Build Package	Package crate	2026-01-08T18:49:59.0122650Z scripts/check-version-modification.mjs
+Build Package	Package crate	2026-01-08T18:49:59.0123062Z scripts/collect-changelog.mjs
+Build Package	Package crate	2026-01-08T18:49:59.0123445Z scripts/create-github-release.mjs
+Build Package	Package crate	2026-01-08T18:49:59.0124192Z scripts/detect-code-changes.mjs
+Build Package	Package crate	2026-01-08T18:49:59.0124523Z scripts/get-bump-type.mjs
+Build Package	Package crate	2026-01-08T18:49:59.0124821Z scripts/git-config.mjs
+Build Package	Package crate	2026-01-08T18:49:59.0125122Z scripts/version-and-commit.mjs
+Build Package	Package crate	2026-01-08T18:49:59.0125432Z src/lib.rs
+Build Package	Post Cache cargo dependencies	﻿2026-01-08T18:49:59.0702246Z Post job cleanup.
+Build Package	Post Cache cargo dependencies	2026-01-08T18:49:59.2110466Z [command]/usr/bin/tar --posix -cf cache.tzst --exclude cache.tzst -P -C /home/runner/work/lino-objects-codec/lino-objects-codec --files-from manifest.txt --use-compress-program zstdmt
+Build Package	Post Cache cargo dependencies	2026-01-08T18:49:59.9740669Z Sent 12372547 of 12372547 (100.0%), 63.1 MBs/sec
+Build Package	Post Cache cargo dependencies	2026-01-08T18:50:00.0780581Z Cache saved with key: Linux-cargo-build-3bdf1052f98aec50857f27e3615100242b9f9c1f98c417d8384cf7fd70b81aba
+Build Package	Post Run actions/checkout@v4	﻿2026-01-08T18:50:00.0898234Z Post job cleanup.
+Build Package	Post Run actions/checkout@v4	2026-01-08T18:50:00.1832220Z [command]/usr/bin/git version
+Build Package	Post Run actions/checkout@v4	2026-01-08T18:50:00.1872706Z git version 2.52.0
+Build Package	Post Run actions/checkout@v4	2026-01-08T18:50:00.1914290Z Temporarily overriding HOME='/home/runner/work/_temp/3c0254e1-f8f6-4d91-963b-a7c425e96fbd' before making global git config changes
+Build Package	Post Run actions/checkout@v4	2026-01-08T18:50:00.1915570Z Adding repository directory to the temporary git global config as a safe directory
+Build Package	Post Run actions/checkout@v4	2026-01-08T18:50:00.1927948Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/lino-objects-codec/lino-objects-codec
+Build Package	Post Run actions/checkout@v4	2026-01-08T18:50:00.1963351Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+Build Package	Post Run actions/checkout@v4	2026-01-08T18:50:00.1996936Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+Build Package	Post Run actions/checkout@v4	2026-01-08T18:50:00.2240269Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Build Package	Post Run actions/checkout@v4	2026-01-08T18:50:00.2262368Z http.https://github.com/.extraheader
+Build Package	Post Run actions/checkout@v4	2026-01-08T18:50:00.2274998Z [command]/usr/bin/git config --local --unset-all http.https://github.com/.extraheader
+Build Package	Post Run actions/checkout@v4	2026-01-08T18:50:00.2306929Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+Build Package	Post Run actions/checkout@v4	2026-01-08T18:50:00.2541317Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+Build Package	Post Run actions/checkout@v4	2026-01-08T18:50:00.2572972Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+Build Package	Complete job	﻿2026-01-08T18:50:00.2922821Z Cleaning up orphan processes
+Auto Release	Set up job	﻿2026-01-08T18:50:04.5308992Z Current runner version: '2.330.0'
+Auto Release	Set up job	2026-01-08T18:50:04.5334778Z ##[group]Runner Image Provisioner
+Auto Release	Set up job	2026-01-08T18:50:04.5335763Z Hosted Compute Agent
+Auto Release	Set up job	2026-01-08T18:50:04.5336328Z Version: 20251211.462
+Auto Release	Set up job	2026-01-08T18:50:04.5336982Z Commit: 6cbad8c2bb55d58165063d031ccabf57e2d2db61
+Auto Release	Set up job	2026-01-08T18:50:04.5339121Z Build Date: 2025-12-11T16:28:49Z
+Auto Release	Set up job	2026-01-08T18:50:04.5339905Z Worker ID: {20b82b29-97a8-4f9d-b46f-67007316f0de}
+Auto Release	Set up job	2026-01-08T18:50:04.5340630Z ##[endgroup]
+Auto Release	Set up job	2026-01-08T18:50:04.5341211Z ##[group]Operating System
+Auto Release	Set up job	2026-01-08T18:50:04.5341840Z Ubuntu
+Auto Release	Set up job	2026-01-08T18:50:04.5342337Z 24.04.3
+Auto Release	Set up job	2026-01-08T18:50:04.5342844Z LTS
+Auto Release	Set up job	2026-01-08T18:50:04.5343581Z ##[endgroup]
+Auto Release	Set up job	2026-01-08T18:50:04.5344157Z ##[group]Runner Image
+Auto Release	Set up job	2026-01-08T18:50:04.5344685Z Image: ubuntu-24.04
+Auto Release	Set up job	2026-01-08T18:50:04.5345339Z Version: 20251215.174.1
+Auto Release	Set up job	2026-01-08T18:50:04.5346492Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20251215.174/images/ubuntu/Ubuntu2404-Readme.md
+Auto Release	Set up job	2026-01-08T18:50:04.5347947Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20251215.174
+Auto Release	Set up job	2026-01-08T18:50:04.5349284Z ##[endgroup]
+Auto Release	Set up job	2026-01-08T18:50:04.5350397Z ##[group]GITHUB_TOKEN Permissions
+Auto Release	Set up job	2026-01-08T18:50:04.5352566Z Contents: write
+Auto Release	Set up job	2026-01-08T18:50:04.5353160Z Metadata: read
+Auto Release	Set up job	2026-01-08T18:50:04.5354321Z ##[endgroup]
+Auto Release	Set up job	2026-01-08T18:50:04.5356861Z Secret source: Actions
+Auto Release	Set up job	2026-01-08T18:50:04.5357903Z Prepare workflow directory
+Auto Release	Set up job	2026-01-08T18:50:04.5754114Z Prepare all required actions
+Auto Release	Set up job	2026-01-08T18:50:04.5792286Z Getting action download info
+Auto Release	Set up job	2026-01-08T18:50:04.9313927Z Download action repository 'actions/checkout@v4' (SHA:34e114876b0b11c390a56381ad16ebd13914f8d5)
+Auto Release	Set up job	2026-01-08T18:50:05.0189759Z Download action repository 'dtolnay/rust-toolchain@stable' (SHA:4be9e76fd7c4901c61fb841f559994984270fce7)
+Auto Release	Set up job	2026-01-08T18:50:05.1552079Z Download action repository 'actions/setup-node@v4' (SHA:49933ea5288caeca8642d1e84afbd3f7d6820020)
+Auto Release	Set up job	2026-01-08T18:50:05.3867645Z Complete job name: Auto Release
+Auto Release	Run actions/checkout@v4	﻿2026-01-08T18:50:05.4637195Z ##[group]Run actions/checkout@v4
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.4638345Z with:
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.4638805Z   fetch-depth: 0
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.4639535Z   token: ***
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.4640029Z   repository: link-foundation/lino-objects-codec
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.4640632Z   ssh-strict: true
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.4641063Z   ssh-user: git
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.4641501Z   persist-credentials: true
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.4641993Z   clean: true
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.4642440Z   sparse-checkout-cone-mode: true
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.4642985Z   fetch-tags: false
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.4643614Z   show-progress: true
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.4644063Z   lfs: false
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.4644465Z   submodules: false
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.4644891Z   set-safe-directory: true
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.4645691Z env:
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.4646113Z   CARGO_TERM_COLOR: always
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.4646620Z   RUSTFLAGS: -Dwarnings
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.4647065Z ##[endgroup]
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.5797056Z Syncing repository: link-foundation/lino-objects-codec
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.5799225Z ##[group]Getting Git version info
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.5800120Z Working directory is '/home/runner/work/lino-objects-codec/lino-objects-codec'
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.5801258Z [command]/usr/bin/git version
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.5909688Z git version 2.52.0
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.5952206Z ##[endgroup]
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.5973056Z Temporarily overriding HOME='/home/runner/work/_temp/ff644163-b710-43f1-96f9-ebac795f7b7d' before making global git config changes
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.5976143Z Adding repository directory to the temporary git global config as a safe directory
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.5981188Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/lino-objects-codec/lino-objects-codec
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.6030806Z Deleting the contents of '/home/runner/work/lino-objects-codec/lino-objects-codec'
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.6035294Z ##[group]Initializing the repository
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.6040716Z [command]/usr/bin/git init /home/runner/work/lino-objects-codec/lino-objects-codec
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.6168733Z hint: Using 'master' as the name for the initial branch. This default branch name
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.6171163Z hint: will change to "main" in Git 3.0. To configure the initial branch name
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.6172881Z hint: to use in all of your new repositories, which will suppress this warning,
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.6173938Z hint: call:
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.6174352Z hint:
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.6174875Z hint: 	git config --global init.defaultBranch <name>
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.6175480Z hint:
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.6176054Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.6176991Z hint: 'development'. The just-created branch can be renamed via this command:
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.6177847Z hint:
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.6178532Z hint: 	git branch -m <name>
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.6179213Z hint:
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.6179858Z hint: Disable this message with "git config set advice.defaultBranchName false"
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.6180960Z Initialized empty Git repository in /home/runner/work/lino-objects-codec/lino-objects-codec/.git/
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.6185099Z [command]/usr/bin/git remote add origin https://github.com/link-foundation/lino-objects-codec
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.6220940Z ##[endgroup]
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.6221736Z ##[group]Disabling automatic garbage collection
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.6225001Z [command]/usr/bin/git config --local gc.auto 0
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.6254708Z ##[endgroup]
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.6255906Z ##[group]Setting up auth
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.6262154Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.6296096Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.6658214Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.6691174Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.6921182Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.6954929Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.7183754Z [command]/usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.7220100Z ##[endgroup]
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.7221098Z ##[group]Fetching the repository
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.7229389Z [command]/usr/bin/git -c protocol.version=2 fetch --prune --no-recurse-submodules origin +refs/heads/*:refs/remotes/origin/* +refs/tags/*:refs/tags/*
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.9715651Z From https://github.com/link-foundation/lino-objects-codec
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.9718099Z  * [new branch]      issue-1-843d779c4cdb  -> origin/issue-1-843d779c4cdb
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.9720246Z  * [new branch]      issue-11-c74c0836aeba -> origin/issue-11-c74c0836aeba
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.9721529Z  * [new branch]      issue-15-b28422959bc5 -> origin/issue-15-b28422959bc5
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.9722759Z  * [new branch]      issue-17-ace5a094a724 -> origin/issue-17-ace5a094a724
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.9724365Z  * [new branch]      issue-20-d21ab54e8ff1 -> origin/issue-20-d21ab54e8ff1
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.9725698Z  * [new branch]      issue-3-397c5eeac29f  -> origin/issue-3-397c5eeac29f
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.9727091Z  * [new branch]      issue-5-9641b6fb00d3  -> origin/issue-5-9641b6fb00d3
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.9728487Z  * [new branch]      issue-7-7a98520cd689  -> origin/issue-7-7a98520cd689
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.9729926Z  * [new branch]      issue-8-8f8d9acce5f1  -> origin/issue-8-8f8d9acce5f1
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.9731368Z  * [new branch]      issue-9-bef9e95e65ef  -> origin/issue-9-bef9e95e65ef
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.9732653Z  * [new branch]      main                  -> origin/main
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.9733953Z  * [new tag]         v0.1.1                -> v0.1.1
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.9735245Z  * [new tag]         v0.3.0                -> v0.3.0
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.9786829Z [command]/usr/bin/git branch --list --remote origin/main
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.9816514Z   origin/main
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.9826884Z [command]/usr/bin/git rev-parse refs/remotes/origin/main
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.9851121Z 57b33900930e484f211863fb09d36188f38fcaeb
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.9866437Z [command]/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules origin +c79c77d68a90cadbd439c9613a7050501095c92d:refs/remotes/origin/main
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.9919331Z From https://github.com/link-foundation/lino-objects-codec
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.9922659Z  + 57b3390...c79c77d c79c77d68a90cadbd439c9613a7050501095c92d -> origin/main  (forced update)
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.9947938Z ##[endgroup]
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.9950242Z ##[group]Determining the checkout info
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.9952528Z ##[endgroup]
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.9954811Z [command]/usr/bin/git sparse-checkout disable
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:05.9994430Z [command]/usr/bin/git config --local --unset-all extensions.worktreeConfig
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:06.0021160Z ##[group]Checking out the ref
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:06.0026041Z [command]/usr/bin/git checkout --progress --force -B main refs/remotes/origin/main
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:06.0160169Z Switched to a new branch 'main'
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:06.0162370Z branch 'main' set up to track 'origin/main'.
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:06.0172301Z ##[endgroup]
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:06.0210694Z [command]/usr/bin/git log -1 --format=%H
+Auto Release	Run actions/checkout@v4	2026-01-08T18:50:06.0233852Z c79c77d68a90cadbd439c9613a7050501095c92d
+Auto Release	Set up Rust	﻿2026-01-08T18:50:06.0799298Z ##[group]Run dtolnay/rust-toolchain@stable
+Auto Release	Set up Rust	2026-01-08T18:50:06.0800547Z with:
+Auto Release	Set up Rust	2026-01-08T18:50:06.0801317Z   toolchain: stable
+Auto Release	Set up Rust	2026-01-08T18:50:06.0802152Z env:
+Auto Release	Set up Rust	2026-01-08T18:50:06.0802915Z   CARGO_TERM_COLOR: always
+Auto Release	Set up Rust	2026-01-08T18:50:06.0804087Z   RUSTFLAGS: -Dwarnings
+Auto Release	Set up Rust	2026-01-08T18:50:06.0805344Z ##[endgroup]
+Auto Release	Set up Rust	2026-01-08T18:50:06.1044993Z ##[group]Run : parse toolchain version
+Auto Release	Set up Rust	2026-01-08T18:50:06.1046268Z [36;1m: parse toolchain version[0m
+Auto Release	Set up Rust	2026-01-08T18:50:06.1047326Z [36;1mif [[ -z $toolchain ]]; then[0m
+Auto Release	Set up Rust	2026-01-08T18:50:06.1049198Z [36;1m  # GitHub does not enforce `required: true` inputs itself. https://github.com/actions/runner/issues/1070[0m
+Auto Release	Set up Rust	2026-01-08T18:50:06.1051203Z [36;1m  echo "'toolchain' is a required input" >&2[0m
+Auto Release	Set up Rust	2026-01-08T18:50:06.1052342Z [36;1m  exit 1[0m
+Auto Release	Set up Rust	2026-01-08T18:50:06.1053809Z [36;1melif [[ $toolchain =~ ^stable' '[0-9]+' '(year|month|week|day)s?' 'ago$ ]]; then[0m
+Auto Release	Set up Rust	2026-01-08T18:50:06.1055360Z [36;1m  if [[ Linux == macOS ]]; then[0m
+Auto Release	Set up Rust	2026-01-08T18:50:06.1057289Z [36;1m    echo "toolchain=1.$((($(date -v-$(sed 's/stable \([0-9]*\) \(.\).*/\1\2/' <<< $toolchain) +%s)/60/60/24-16569)/7/6))" >> $GITHUB_OUTPUT[0m
+Auto Release	Set up Rust	2026-01-08T18:50:06.1059248Z [36;1m  else[0m
+Auto Release	Set up Rust	2026-01-08T18:50:06.1060743Z [36;1m    echo "toolchain=1.$((($(date --date "${toolchain#stable }" +%s)/60/60/24-16569)/7/6))" >> $GITHUB_OUTPUT[0m
+Auto Release	Set up Rust	2026-01-08T18:50:06.1062463Z [36;1m  fi[0m
+Auto Release	Set up Rust	2026-01-08T18:50:06.1063774Z [36;1melif [[ $toolchain =~ ^stable' 'minus' '[0-9]+' 'releases?$ ]]; then[0m
+Auto Release	Set up Rust	2026-01-08T18:50:06.1065751Z [36;1m  echo "toolchain=1.$((($(date +%s)/60/60/24-16569)/7/6-${toolchain//[^0-9]/}))" >> $GITHUB_OUTPUT[0m
+Auto Release	Set up Rust	2026-01-08T18:50:06.1067466Z [36;1melif [[ $toolchain =~ ^1\.[0-9]+$ ]]; then[0m
+Auto Release	Set up Rust	2026-01-08T18:50:06.1069434Z [36;1m  echo "toolchain=1.$((i=${toolchain#1.}, c=($(date +%s)/60/60/24-16569)/7/6, i+9*i*(10*i<=c)+90*i*(100*i<=c)))" >> $GITHUB_OUTPUT[0m
+Auto Release	Set up Rust	2026-01-08T18:50:06.1071298Z [36;1melse[0m
+Auto Release	Set up Rust	2026-01-08T18:50:06.1072225Z [36;1m  echo "toolchain=$toolchain" >> $GITHUB_OUTPUT[0m
+Auto Release	Set up Rust	2026-01-08T18:50:06.1073575Z [36;1mfi[0m
+Auto Release	Set up Rust	2026-01-08T18:50:06.1111869Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Auto Release	Set up Rust	2026-01-08T18:50:06.1113138Z env:
+Auto Release	Set up Rust	2026-01-08T18:50:06.1114145Z   CARGO_TERM_COLOR: always
+Auto Release	Set up Rust	2026-01-08T18:50:06.1115044Z   RUSTFLAGS: -Dwarnings
+Auto Release	Set up Rust	2026-01-08T18:50:06.1115903Z   toolchain: stable
+Auto Release	Set up Rust	2026-01-08T18:50:06.1116682Z ##[endgroup]
+Auto Release	Set up Rust	2026-01-08T18:50:06.1291428Z ##[group]Run : construct rustup command line
+Auto Release	Set up Rust	2026-01-08T18:50:06.1292587Z [36;1m: construct rustup command line[0m
+Auto Release	Set up Rust	2026-01-08T18:50:06.1294419Z [36;1mecho "targets=$(for t in ${targets//,/ }; do echo -n ' --target' $t; done)" >> $GITHUB_OUTPUT[0m
+Auto Release	Set up Rust	2026-01-08T18:50:06.1296668Z [36;1mecho "components=$(for c in ${components//,/ }; do echo -n ' --component' $c; done)" >> $GITHUB_OUTPUT[0m
+Auto Release	Set up Rust	2026-01-08T18:50:06.1298421Z [36;1mecho "downgrade=" >> $GITHUB_OUTPUT[0m
+Auto Release	Set up Rust	2026-01-08T18:50:06.1331595Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Auto Release	Set up Rust	2026-01-08T18:50:06.1332776Z env:
+Auto Release	Set up Rust	2026-01-08T18:50:06.1333734Z   CARGO_TERM_COLOR: always
+Auto Release	Set up Rust	2026-01-08T18:50:06.1334622Z   RUSTFLAGS: -Dwarnings
+Auto Release	Set up Rust	2026-01-08T18:50:06.1335418Z   targets: 
+Auto Release	Set up Rust	2026-01-08T18:50:06.1336101Z   components: 
+Auto Release	Set up Rust	2026-01-08T18:50:06.1336816Z ##[endgroup]
+Auto Release	Set up Rust	2026-01-08T18:50:06.1454917Z ##[group]Run : set $CARGO_HOME
+Auto Release	Set up Rust	2026-01-08T18:50:06.1455857Z [36;1m: set $CARGO_HOME[0m
+Auto Release	Set up Rust	2026-01-08T18:50:06.1457022Z [36;1mecho CARGO_HOME=${CARGO_HOME:-"$HOME/.cargo"} >> $GITHUB_ENV[0m
+Auto Release	Set up Rust	2026-01-08T18:50:06.1491485Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Auto Release	Set up Rust	2026-01-08T18:50:06.1492699Z env:
+Auto Release	Set up Rust	2026-01-08T18:50:06.1493530Z   CARGO_TERM_COLOR: always
+Auto Release	Set up Rust	2026-01-08T18:50:06.1494387Z   RUSTFLAGS: -Dwarnings
+Auto Release	Set up Rust	2026-01-08T18:50:06.1495176Z ##[endgroup]
+Auto Release	Set up Rust	2026-01-08T18:50:06.1616590Z ##[group]Run : install rustup if needed
+Auto Release	Set up Rust	2026-01-08T18:50:06.1617676Z [36;1m: install rustup if needed[0m
+Auto Release	Set up Rust	2026-01-08T18:50:06.1618732Z [36;1mif ! command -v rustup &>/dev/null; then[0m
+Auto Release	Set up Rust	2026-01-08T18:50:06.1621293Z [36;1m  curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused --location --silent --show-error --fail https://sh.rustup.rs | sh -s -- --default-toolchain none -y[0m
+Auto Release	Set up Rust	2026-01-08T18:50:06.1624359Z [36;1m  echo "$CARGO_HOME/bin" >> $GITHUB_PATH[0m
+Auto Release	Set up Rust	2026-01-08T18:50:06.1625405Z [36;1mfi[0m
+Auto Release	Set up Rust	2026-01-08T18:50:06.1658521Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Auto Release	Set up Rust	2026-01-08T18:50:06.1659696Z env:
+Auto Release	Set up Rust	2026-01-08T18:50:06.1660437Z   CARGO_TERM_COLOR: always
+Auto Release	Set up Rust	2026-01-08T18:50:06.1661309Z   RUSTFLAGS: -Dwarnings
+Auto Release	Set up Rust	2026-01-08T18:50:06.1662127Z   CARGO_HOME: /home/runner/.cargo
+Auto Release	Set up Rust	2026-01-08T18:50:06.1663001Z ##[endgroup]
+Auto Release	Set up Rust	2026-01-08T18:50:06.1787036Z ##[group]Run rustup toolchain install stable --profile minimal --no-self-update
+Auto Release	Set up Rust	2026-01-08T18:50:06.1788938Z [36;1mrustup toolchain install stable --profile minimal --no-self-update[0m
+Auto Release	Set up Rust	2026-01-08T18:50:06.1822027Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Auto Release	Set up Rust	2026-01-08T18:50:06.1823418Z env:
+Auto Release	Set up Rust	2026-01-08T18:50:06.1824117Z   CARGO_TERM_COLOR: always
+Auto Release	Set up Rust	2026-01-08T18:50:06.1824955Z   RUSTFLAGS: -Dwarnings
+Auto Release	Set up Rust	2026-01-08T18:50:06.1825793Z   CARGO_HOME: /home/runner/.cargo
+Auto Release	Set up Rust	2026-01-08T18:50:06.1826736Z   RUSTUP_PERMIT_COPY_RENAME: 1
+Auto Release	Set up Rust	2026-01-08T18:50:06.1827592Z ##[endgroup]
+Auto Release	Set up Rust	2026-01-08T18:50:07.8118716Z info: syncing channel updates for 'stable-x86_64-unknown-linux-gnu'
+Auto Release	Set up Rust	2026-01-08T18:50:08.3650634Z 
+Auto Release	Set up Rust	2026-01-08T18:50:08.3743729Z   stable-x86_64-unknown-linux-gnu unchanged - rustc 1.92.0 (ded5c06cf 2025-12-08)
+Auto Release	Set up Rust	2026-01-08T18:50:08.3744812Z 
+Auto Release	Set up Rust	2026-01-08T18:50:08.3804378Z ##[group]Run rustup default stable
+Auto Release	Set up Rust	2026-01-08T18:50:08.3804736Z [36;1mrustup default stable[0m
+Auto Release	Set up Rust	2026-01-08T18:50:08.3839084Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Auto Release	Set up Rust	2026-01-08T18:50:08.3839448Z env:
+Auto Release	Set up Rust	2026-01-08T18:50:08.3839669Z   CARGO_TERM_COLOR: always
+Auto Release	Set up Rust	2026-01-08T18:50:08.3839919Z   RUSTFLAGS: -Dwarnings
+Auto Release	Set up Rust	2026-01-08T18:50:08.3840172Z   CARGO_HOME: /home/runner/.cargo
+Auto Release	Set up Rust	2026-01-08T18:50:08.3840431Z ##[endgroup]
+Auto Release	Set up Rust	2026-01-08T18:50:08.3946020Z info: using existing install for 'stable-x86_64-unknown-linux-gnu'
+Auto Release	Set up Rust	2026-01-08T18:50:08.4324560Z info: default toolchain set to 'stable-x86_64-unknown-linux-gnu'
+Auto Release	Set up Rust	2026-01-08T18:50:08.4325411Z 
+Auto Release	Set up Rust	2026-01-08T18:50:08.4422422Z   stable-x86_64-unknown-linux-gnu unchanged - rustc 1.92.0 (ded5c06cf 2025-12-08)
+Auto Release	Set up Rust	2026-01-08T18:50:08.4423460Z 
+Auto Release	Set up Rust	2026-01-08T18:50:08.4474042Z ##[group]Run : create cachekey
+Auto Release	Set up Rust	2026-01-08T18:50:08.4474382Z [36;1m: create cachekey[0m
+Auto Release	Set up Rust	2026-01-08T18:50:08.4474915Z [36;1mDATE=$(rustc +stable --version --verbose | sed -ne 's/^commit-date: \(20[0-9][0-9]\)-\([01][0-9]\)-\([0-3][0-9]\)$/\1\2\3/p')[0m
+Auto Release	Set up Rust	2026-01-08T18:50:08.4475871Z [36;1mHASH=$(rustc +stable --version --verbose | sed -ne 's/^commit-hash: //p')[0m
+Auto Release	Set up Rust	2026-01-08T18:50:08.4476405Z [36;1mecho "cachekey=$(echo $DATE$HASH | head -c12)" >> $GITHUB_OUTPUT[0m
+Auto Release	Set up Rust	2026-01-08T18:50:08.4510392Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Auto Release	Set up Rust	2026-01-08T18:50:08.4510755Z env:
+Auto Release	Set up Rust	2026-01-08T18:50:08.4510970Z   CARGO_TERM_COLOR: always
+Auto Release	Set up Rust	2026-01-08T18:50:08.4511236Z   RUSTFLAGS: -Dwarnings
+Auto Release	Set up Rust	2026-01-08T18:50:08.4511489Z   CARGO_HOME: /home/runner/.cargo
+Auto Release	Set up Rust	2026-01-08T18:50:08.4511765Z ##[endgroup]
+Auto Release	Set up Rust	2026-01-08T18:50:08.5244318Z ##[group]Run : disable incremental compilation
+Auto Release	Set up Rust	2026-01-08T18:50:08.5244756Z [36;1m: disable incremental compilation[0m
+Auto Release	Set up Rust	2026-01-08T18:50:08.5245125Z [36;1mif [ -z "${CARGO_INCREMENTAL+set}" ]; then[0m
+Auto Release	Set up Rust	2026-01-08T18:50:08.5245494Z [36;1m  echo CARGO_INCREMENTAL=0 >> $GITHUB_ENV[0m
+Auto Release	Set up Rust	2026-01-08T18:50:08.5245793Z [36;1mfi[0m
+Auto Release	Set up Rust	2026-01-08T18:50:08.5279678Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Auto Release	Set up Rust	2026-01-08T18:50:08.5280087Z env:
+Auto Release	Set up Rust	2026-01-08T18:50:08.5280298Z   CARGO_TERM_COLOR: always
+Auto Release	Set up Rust	2026-01-08T18:50:08.5280561Z   RUSTFLAGS: -Dwarnings
+Auto Release	Set up Rust	2026-01-08T18:50:08.5280812Z   CARGO_HOME: /home/runner/.cargo
+Auto Release	Set up Rust	2026-01-08T18:50:08.5281076Z ##[endgroup]
+Auto Release	Set up Rust	2026-01-08T18:50:08.5360230Z ##[group]Run : enable colors in Cargo output
+Auto Release	Set up Rust	2026-01-08T18:50:08.5360595Z [36;1m: enable colors in Cargo output[0m
+Auto Release	Set up Rust	2026-01-08T18:50:08.5360918Z [36;1mif [ -z "${CARGO_TERM_COLOR+set}" ]; then[0m
+Auto Release	Set up Rust	2026-01-08T18:50:08.5361278Z [36;1m  echo CARGO_TERM_COLOR=always >> $GITHUB_ENV[0m
+Auto Release	Set up Rust	2026-01-08T18:50:08.5361775Z [36;1mfi[0m
+Auto Release	Set up Rust	2026-01-08T18:50:08.5394413Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Auto Release	Set up Rust	2026-01-08T18:50:08.5394783Z env:
+Auto Release	Set up Rust	2026-01-08T18:50:08.5394990Z   CARGO_TERM_COLOR: always
+Auto Release	Set up Rust	2026-01-08T18:50:08.5395248Z   RUSTFLAGS: -Dwarnings
+Auto Release	Set up Rust	2026-01-08T18:50:08.5395498Z   CARGO_HOME: /home/runner/.cargo
+Auto Release	Set up Rust	2026-01-08T18:50:08.5395765Z   CARGO_INCREMENTAL: 0
+Auto Release	Set up Rust	2026-01-08T18:50:08.5396016Z ##[endgroup]
+Auto Release	Set up Rust	2026-01-08T18:50:08.5477396Z ##[group]Run : enable Cargo sparse registry
+Auto Release	Set up Rust	2026-01-08T18:50:08.5477770Z [36;1m: enable Cargo sparse registry[0m
+Auto Release	Set up Rust	2026-01-08T18:50:08.5478159Z [36;1m# implemented in 1.66, stabilized in 1.68, made default in 1.70[0m
+Auto Release	Set up Rust	2026-01-08T18:50:08.5478880Z [36;1mif [ -z "${CARGO_REGISTRIES_CRATES_IO_PROTOCOL+set}" -o -f "/home/runner/work/_temp"/.implicit_cargo_registries_crates_io_protocol ]; then[0m
+Auto Release	Set up Rust	2026-01-08T18:50:08.5479630Z [36;1m  if rustc +stable --version --verbose | grep -q '^release: 1\.6[89]\.'; then[0m
+Auto Release	Set up Rust	2026-01-08T18:50:08.5480237Z [36;1m    touch "/home/runner/work/_temp"/.implicit_cargo_registries_crates_io_protocol || true[0m
+Auto Release	Set up Rust	2026-01-08T18:50:08.5480813Z [36;1m    echo CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse >> $GITHUB_ENV[0m
+Auto Release	Set up Rust	2026-01-08T18:50:08.5481336Z [36;1m  elif rustc +stable --version --verbose | grep -q '^release: 1\.6[67]\.'; then[0m
+Auto Release	Set up Rust	2026-01-08T18:50:08.5481927Z [36;1m    touch "/home/runner/work/_temp"/.implicit_cargo_registries_crates_io_protocol || true[0m
+Auto Release	Set up Rust	2026-01-08T18:50:08.5482483Z [36;1m    echo CARGO_REGISTRIES_CRATES_IO_PROTOCOL=git >> $GITHUB_ENV[0m
+Auto Release	Set up Rust	2026-01-08T18:50:08.5482841Z [36;1m  fi[0m
+Auto Release	Set up Rust	2026-01-08T18:50:08.5483052Z [36;1mfi[0m
+Auto Release	Set up Rust	2026-01-08T18:50:08.5515927Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Auto Release	Set up Rust	2026-01-08T18:50:08.5516295Z env:
+Auto Release	Set up Rust	2026-01-08T18:50:08.5516512Z   CARGO_TERM_COLOR: always
+Auto Release	Set up Rust	2026-01-08T18:50:08.5516760Z   RUSTFLAGS: -Dwarnings
+Auto Release	Set up Rust	2026-01-08T18:50:08.5517011Z   CARGO_HOME: /home/runner/.cargo
+Auto Release	Set up Rust	2026-01-08T18:50:08.5517271Z   CARGO_INCREMENTAL: 0
+Auto Release	Set up Rust	2026-01-08T18:50:08.5517502Z ##[endgroup]
+Auto Release	Set up Rust	2026-01-08T18:50:08.5905814Z ##[group]Run : work around spurious network errors in curl 8.0
+Auto Release	Set up Rust	2026-01-08T18:50:08.5906333Z [36;1m: work around spurious network errors in curl 8.0[0m
+Auto Release	Set up Rust	2026-01-08T18:50:08.5907085Z [36;1m# https://rust-lang.zulipchat.com/#narrow/stream/246057-t-cargo/topic/timeout.20investigation[0m
+Auto Release	Set up Rust	2026-01-08T18:50:08.5907740Z [36;1mif rustc +stable --version --verbose | grep -q '^release: 1\.7[01]\.'; then[0m
+Auto Release	Set up Rust	2026-01-08T18:50:08.5908415Z [36;1m  echo CARGO_HTTP_MULTIPLEXING=false >> $GITHUB_ENV[0m
+Auto Release	Set up Rust	2026-01-08T18:50:08.5908752Z [36;1mfi[0m
+Auto Release	Set up Rust	2026-01-08T18:50:08.5944444Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Auto Release	Set up Rust	2026-01-08T18:50:08.5944828Z env:
+Auto Release	Set up Rust	2026-01-08T18:50:08.5945042Z   CARGO_TERM_COLOR: always
+Auto Release	Set up Rust	2026-01-08T18:50:08.5945299Z   RUSTFLAGS: -Dwarnings
+Auto Release	Set up Rust	2026-01-08T18:50:08.5945554Z   CARGO_HOME: /home/runner/.cargo
+Auto Release	Set up Rust	2026-01-08T18:50:08.5945847Z   CARGO_INCREMENTAL: 0
+Auto Release	Set up Rust	2026-01-08T18:50:08.5946076Z ##[endgroup]
+Auto Release	Set up Rust	2026-01-08T18:50:08.6205155Z ##[group]Run rustc +stable --version --verbose
+Auto Release	Set up Rust	2026-01-08T18:50:08.6205591Z [36;1mrustc +stable --version --verbose[0m
+Auto Release	Set up Rust	2026-01-08T18:50:08.6240939Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Auto Release	Set up Rust	2026-01-08T18:50:08.6241333Z env:
+Auto Release	Set up Rust	2026-01-08T18:50:08.6241551Z   CARGO_TERM_COLOR: always
+Auto Release	Set up Rust	2026-01-08T18:50:08.6241816Z   RUSTFLAGS: -Dwarnings
+Auto Release	Set up Rust	2026-01-08T18:50:08.6242067Z   CARGO_HOME: /home/runner/.cargo
+Auto Release	Set up Rust	2026-01-08T18:50:08.6242355Z   CARGO_INCREMENTAL: 0
+Auto Release	Set up Rust	2026-01-08T18:50:08.6242582Z ##[endgroup]
+Auto Release	Set up Rust	2026-01-08T18:50:08.6433110Z rustc 1.92.0 (ded5c06cf 2025-12-08)
+Auto Release	Set up Rust	2026-01-08T18:50:08.6434365Z binary: rustc
+Auto Release	Set up Rust	2026-01-08T18:50:08.6434879Z commit-hash: ded5c06cf21d2b93bffd5d884aa6e96934ee4234
+Auto Release	Set up Rust	2026-01-08T18:50:08.6435560Z commit-date: 2025-12-08
+Auto Release	Set up Rust	2026-01-08T18:50:08.6436039Z host: x86_64-unknown-linux-gnu
+Auto Release	Set up Rust	2026-01-08T18:50:08.6436389Z release: 1.92.0
+Auto Release	Set up Rust	2026-01-08T18:50:08.6436657Z LLVM version: 21.1.3
+Auto Release	Setup Node.js	﻿2026-01-08T18:50:08.6570832Z ##[group]Run actions/setup-node@v4
+Auto Release	Setup Node.js	2026-01-08T18:50:08.6571170Z with:
+Auto Release	Setup Node.js	2026-01-08T18:50:08.6571385Z   node-version: 22
+Auto Release	Setup Node.js	2026-01-08T18:50:08.6571613Z   always-auth: false
+Auto Release	Setup Node.js	2026-01-08T18:50:08.6571848Z   check-latest: false
+Auto Release	Setup Node.js	2026-01-08T18:50:08.6572231Z   token: ***
+Auto Release	Setup Node.js	2026-01-08T18:50:08.6572440Z env:
+Auto Release	Setup Node.js	2026-01-08T18:50:08.6572650Z   CARGO_TERM_COLOR: always
+Auto Release	Setup Node.js	2026-01-08T18:50:08.6572903Z   RUSTFLAGS: -Dwarnings
+Auto Release	Setup Node.js	2026-01-08T18:50:08.6573159Z   CARGO_HOME: /home/runner/.cargo
+Auto Release	Setup Node.js	2026-01-08T18:50:08.6573733Z   CARGO_INCREMENTAL: 0
+Auto Release	Setup Node.js	2026-01-08T18:50:08.6574007Z ##[endgroup]
+Auto Release	Setup Node.js	2026-01-08T18:50:08.8562635Z Found in cache @ /opt/hostedtoolcache/node/22.21.1/x64
+Auto Release	Setup Node.js	2026-01-08T18:50:08.8569928Z ##[group]Environment details
+Auto Release	Setup Node.js	2026-01-08T18:50:11.2062559Z node: v22.21.1
+Auto Release	Setup Node.js	2026-01-08T18:50:11.2062978Z npm: 10.9.4
+Auto Release	Setup Node.js	2026-01-08T18:50:11.2063473Z yarn: 1.22.22
+Auto Release	Setup Node.js	2026-01-08T18:50:11.2064479Z ##[endgroup]
+Auto Release	Configure git	﻿2026-01-08T18:50:11.2151693Z ##[group]Run node scripts/git-config.mjs
+Auto Release	Configure git	2026-01-08T18:50:11.2152031Z [36;1mnode scripts/git-config.mjs[0m
+Auto Release	Configure git	2026-01-08T18:50:11.2190651Z shell: /usr/bin/bash -e {0}
+Auto Release	Configure git	2026-01-08T18:50:11.2190901Z env:
+Auto Release	Configure git	2026-01-08T18:50:11.2191073Z   CARGO_TERM_COLOR: always
+Auto Release	Configure git	2026-01-08T18:50:11.2191306Z   RUSTFLAGS: -Dwarnings
+Auto Release	Configure git	2026-01-08T18:50:11.2191539Z   CARGO_HOME: /home/runner/.cargo
+Auto Release	Configure git	2026-01-08T18:50:11.2191778Z   CARGO_INCREMENTAL: 0
+Auto Release	Configure git	2026-01-08T18:50:11.2191984Z ##[endgroup]
+Auto Release	Configure git	2026-01-08T18:50:11.2495922Z Configuring git user: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
+Auto Release	Configure git	2026-01-08T18:50:11.2568244Z Git configuration complete
+Auto Release	Determine bump type from changelog fragments	﻿2026-01-08T18:50:11.2632075Z ##[group]Run node scripts/get-bump-type.mjs
+Auto Release	Determine bump type from changelog fragments	2026-01-08T18:50:11.2632442Z [36;1mnode scripts/get-bump-type.mjs[0m
+Auto Release	Determine bump type from changelog fragments	2026-01-08T18:50:11.2665836Z shell: /usr/bin/bash -e {0}
+Auto Release	Determine bump type from changelog fragments	2026-01-08T18:50:11.2666186Z env:
+Auto Release	Determine bump type from changelog fragments	2026-01-08T18:50:11.2666448Z   CARGO_TERM_COLOR: always
+Auto Release	Determine bump type from changelog fragments	2026-01-08T18:50:11.2666795Z   RUSTFLAGS: -Dwarnings
+Auto Release	Determine bump type from changelog fragments	2026-01-08T18:50:11.2667315Z   CARGO_HOME: /home/runner/.cargo
+Auto Release	Determine bump type from changelog fragments	2026-01-08T18:50:11.2667743Z   CARGO_INCREMENTAL: 0
+Auto Release	Determine bump type from changelog fragments	2026-01-08T18:50:11.2668092Z ##[endgroup]
+Auto Release	Determine bump type from changelog fragments	2026-01-08T18:50:11.2979668Z Found 1 fragment(s)
+Auto Release	Determine bump type from changelog fragments	2026-01-08T18:50:11.2982546Z Highest bump type: patch
+Auto Release	Determine bump type from changelog fragments	2026-01-08T18:50:11.2983039Z bump_type=patch
+Auto Release	Check if version already released	﻿2026-01-08T18:50:11.3046884Z ##[group]Run # Get current version from Cargo.toml
+Auto Release	Check if version already released	2026-01-08T18:50:11.3047304Z [36;1m# Get current version from Cargo.toml[0m
+Auto Release	Check if version already released	2026-01-08T18:50:11.3047696Z [36;1mCURRENT_VERSION=$(grep -Po '(?<=^version = ")[^"]*' Cargo.toml)[0m
+Auto Release	Check if version already released	2026-01-08T18:50:11.3048139Z [36;1mecho "current_version=$CURRENT_VERSION" >> $GITHUB_OUTPUT[0m
+Auto Release	Check if version already released	2026-01-08T18:50:11.3048644Z [36;1m[0m
+Auto Release	Check if version already released	2026-01-08T18:50:11.3048832Z [36;1m# Check if tag exists[0m
+Auto Release	Check if version already released	2026-01-08T18:50:11.3049163Z [36;1mif git rev-parse "rust-v$CURRENT_VERSION" >/dev/null 2>&1; then[0m
+Auto Release	Check if version already released	2026-01-08T18:50:11.3049563Z [36;1m  echo "Tag rust-v$CURRENT_VERSION already exists"[0m
+Auto Release	Check if version already released	2026-01-08T18:50:11.3049914Z [36;1m  echo "should_release=false" >> $GITHUB_OUTPUT[0m
+Auto Release	Check if version already released	2026-01-08T18:50:11.3050185Z [36;1melse[0m
+Auto Release	Check if version already released	2026-01-08T18:50:11.3050415Z [36;1m  echo "New version detected: $CURRENT_VERSION"[0m
+Auto Release	Check if version already released	2026-01-08T18:50:11.3050736Z [36;1m  echo "should_release=true" >> $GITHUB_OUTPUT[0m
+Auto Release	Check if version already released	2026-01-08T18:50:11.3051018Z [36;1mfi[0m
+Auto Release	Check if version already released	2026-01-08T18:50:11.3083066Z shell: /usr/bin/bash -e {0}
+Auto Release	Check if version already released	2026-01-08T18:50:11.3083565Z env:
+Auto Release	Check if version already released	2026-01-08T18:50:11.3083759Z   CARGO_TERM_COLOR: always
+Auto Release	Check if version already released	2026-01-08T18:50:11.3083976Z   RUSTFLAGS: -Dwarnings
+Auto Release	Check if version already released	2026-01-08T18:50:11.3084199Z   CARGO_HOME: /home/runner/.cargo
+Auto Release	Check if version already released	2026-01-08T18:50:11.3084435Z   CARGO_INCREMENTAL: 0
+Auto Release	Check if version already released	2026-01-08T18:50:11.3084637Z ##[endgroup]
+Auto Release	Check if version already released	2026-01-08T18:50:11.3172239Z New version detected: 0.2.0
+Auto Release	Get current version	﻿2026-01-08T18:50:11.3217961Z ##[group]Run VERSION=$(grep -Po '(?<=^version = ")[^"]*' Cargo.toml)
+Auto Release	Get current version	2026-01-08T18:50:11.3218459Z [36;1mVERSION=$(grep -Po '(?<=^version = ")[^"]*' Cargo.toml)[0m
+Auto Release	Get current version	2026-01-08T18:50:11.3218828Z [36;1mecho "version=$VERSION" >> $GITHUB_OUTPUT[0m
+Auto Release	Get current version	2026-01-08T18:50:11.3249391Z shell: /usr/bin/bash -e {0}
+Auto Release	Get current version	2026-01-08T18:50:11.3249633Z env:
+Auto Release	Get current version	2026-01-08T18:50:11.3249811Z   CARGO_TERM_COLOR: always
+Auto Release	Get current version	2026-01-08T18:50:11.3250037Z   RUSTFLAGS: -Dwarnings
+Auto Release	Get current version	2026-01-08T18:50:11.3250253Z   CARGO_HOME: /home/runner/.cargo
+Auto Release	Get current version	2026-01-08T18:50:11.3250494Z   CARGO_INCREMENTAL: 0
+Auto Release	Get current version	2026-01-08T18:50:11.3250689Z ##[endgroup]
+Auto Release	Build release	﻿2026-01-08T18:50:11.3343142Z ##[group]Run cargo build --release
+Auto Release	Build release	2026-01-08T18:50:11.3343802Z [36;1mcargo build --release[0m
+Auto Release	Build release	2026-01-08T18:50:11.3373632Z shell: /usr/bin/bash -e {0}
+Auto Release	Build release	2026-01-08T18:50:11.3373876Z env:
+Auto Release	Build release	2026-01-08T18:50:11.3374052Z   CARGO_TERM_COLOR: always
+Auto Release	Build release	2026-01-08T18:50:11.3374287Z   RUSTFLAGS: -Dwarnings
+Auto Release	Build release	2026-01-08T18:50:11.3374514Z   CARGO_HOME: /home/runner/.cargo
+Auto Release	Build release	2026-01-08T18:50:11.3374759Z   CARGO_INCREMENTAL: 0
+Auto Release	Build release	2026-01-08T18:50:11.3374960Z ##[endgroup]
+Auto Release	Build release	2026-01-08T18:50:12.5731275Z [1m[92m    Updating[0m crates.io index
+Auto Release	Build release	2026-01-08T18:50:12.9144682Z [1m[92m Downloading[0m crates ...
+Auto Release	Build release	2026-01-08T18:50:12.9476276Z [1m[92m  Downloaded[0m base64 v0.22.1
+Auto Release	Build release	2026-01-08T18:50:12.9747952Z [1m[92m  Downloaded[0m links-notation v0.13.0
+Auto Release	Build release	2026-01-08T18:50:12.9770132Z [1m[92m  Downloaded[0m nom v8.0.0
+Auto Release	Build release	2026-01-08T18:50:12.9825170Z [1m[92m  Downloaded[0m memchr v2.7.6
+Auto Release	Build release	2026-01-08T18:50:13.0189406Z [1m[92m   Compiling[0m memchr v2.7.6
+Auto Release	Build release	2026-01-08T18:50:13.0190458Z [1m[92m   Compiling[0m base64 v0.22.1
+Auto Release	Build release	2026-01-08T18:50:15.6288853Z [1m[92m   Compiling[0m nom v8.0.0
+Auto Release	Build release	2026-01-08T18:50:18.6497296Z [1m[92m   Compiling[0m links-notation v0.13.0
+Auto Release	Build release	2026-01-08T18:50:19.0252256Z [1m[92m   Compiling[0m lino-objects-codec v0.2.0 (/home/runner/work/lino-objects-codec/lino-objects-codec/rust)
+Auto Release	Build release	2026-01-08T18:50:19.9127989Z [1m[92m    Finished[0m `release` profile [optimized] target(s) in 8.13s
+Auto Release	Publish to crates.io	﻿2026-01-08T18:50:19.9232949Z ##[group]Run if [ -z "$CARGO_REGISTRY_TOKEN" ]; then
+Auto Release	Publish to crates.io	2026-01-08T18:50:19.9233661Z [36;1mif [ -z "$CARGO_REGISTRY_TOKEN" ]; then[0m
+Auto Release	Publish to crates.io	2026-01-08T18:50:19.9234100Z [36;1m  echo "::warning::CARGO_REGISTRY_TOKEN not set, skipping publish to crates.io"[0m
+Auto Release	Publish to crates.io	2026-01-08T18:50:19.9234504Z [36;1melse[0m
+Auto Release	Publish to crates.io	2026-01-08T18:50:19.9234688Z [36;1m  cargo publish[0m
+Auto Release	Publish to crates.io	2026-01-08T18:50:19.9234894Z [36;1mfi[0m
+Auto Release	Publish to crates.io	2026-01-08T18:50:19.9267178Z shell: /usr/bin/bash -e {0}
+Auto Release	Publish to crates.io	2026-01-08T18:50:19.9267422Z env:
+Auto Release	Publish to crates.io	2026-01-08T18:50:19.9267600Z   CARGO_TERM_COLOR: always
+Auto Release	Publish to crates.io	2026-01-08T18:50:19.9267831Z   RUSTFLAGS: -Dwarnings
+Auto Release	Publish to crates.io	2026-01-08T18:50:19.9268056Z   CARGO_HOME: /home/runner/.cargo
+Auto Release	Publish to crates.io	2026-01-08T18:50:19.9268297Z   CARGO_INCREMENTAL: 0
+Auto Release	Publish to crates.io	2026-01-08T18:50:19.9268502Z   CARGO_REGISTRY_TOKEN: 
+Auto Release	Publish to crates.io	2026-01-08T18:50:19.9268704Z ##[endgroup]
+Auto Release	Publish to crates.io	2026-01-08T18:50:19.9336734Z ##[warning]CARGO_REGISTRY_TOKEN not set, skipping publish to crates.io
+Auto Release	Create GitHub Release	﻿2026-01-08T18:50:19.9377857Z ##[group]Run node scripts/create-github-release.mjs \
+Auto Release	Create GitHub Release	2026-01-08T18:50:19.9378448Z [36;1mnode scripts/create-github-release.mjs \[0m
+Auto Release	Create GitHub Release	2026-01-08T18:50:19.9378767Z [36;1m  --version "0.2.0" \[0m
+Auto Release	Create GitHub Release	2026-01-08T18:50:19.9379064Z [36;1m  --repository "link-foundation/lino-objects-codec" \[0m
+Auto Release	Create GitHub Release	2026-01-08T18:50:19.9379400Z [36;1m  --tag-prefix "rust-v"[0m
+Auto Release	Create GitHub Release	2026-01-08T18:50:19.9408685Z shell: /usr/bin/bash -e {0}
+Auto Release	Create GitHub Release	2026-01-08T18:50:19.9408919Z env:
+Auto Release	Create GitHub Release	2026-01-08T18:50:19.9409101Z   CARGO_TERM_COLOR: always
+Auto Release	Create GitHub Release	2026-01-08T18:50:19.9409323Z   RUSTFLAGS: -Dwarnings
+Auto Release	Create GitHub Release	2026-01-08T18:50:19.9409546Z   CARGO_HOME: /home/runner/.cargo
+Auto Release	Create GitHub Release	2026-01-08T18:50:19.9409775Z   CARGO_INCREMENTAL: 0
+Auto Release	Create GitHub Release	2026-01-08T18:50:19.9410185Z   GH_TOKEN: ***
+Auto Release	Create GitHub Release	2026-01-08T18:50:19.9410385Z ##[endgroup]
+Auto Release	Create GitHub Release	2026-01-08T18:50:24.1957406Z Error: Missing required arguments
+Auto Release	Create GitHub Release	2026-01-08T18:50:24.1958568Z Usage: node scripts/create-github-release.mjs --version <version> --repository <repository>
+Auto Release	Create GitHub Release	2026-01-08T18:50:24.2028059Z ##[error]Process completed with exit code 1.
+Auto Release	Post Run actions/checkout@v4	﻿2026-01-08T18:50:24.2094755Z Post job cleanup.
+Auto Release	Post Run actions/checkout@v4	2026-01-08T18:50:24.3095926Z [command]/usr/bin/git version
+Auto Release	Post Run actions/checkout@v4	2026-01-08T18:50:24.3135330Z git version 2.52.0
+Auto Release	Post Run actions/checkout@v4	2026-01-08T18:50:24.3188939Z Temporarily overriding HOME='/home/runner/work/_temp/2c85f24d-e9cd-4972-b019-f14a50f7069c' before making global git config changes
+Auto Release	Post Run actions/checkout@v4	2026-01-08T18:50:24.3189938Z Adding repository directory to the temporary git global config as a safe directory
+Auto Release	Post Run actions/checkout@v4	2026-01-08T18:50:24.3194680Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/lino-objects-codec/lino-objects-codec
+Auto Release	Post Run actions/checkout@v4	2026-01-08T18:50:24.3232008Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+Auto Release	Post Run actions/checkout@v4	2026-01-08T18:50:24.3267435Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+Auto Release	Post Run actions/checkout@v4	2026-01-08T18:50:24.3503710Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Auto Release	Post Run actions/checkout@v4	2026-01-08T18:50:24.3527837Z http.https://github.com/.extraheader
+Auto Release	Post Run actions/checkout@v4	2026-01-08T18:50:24.3541059Z [command]/usr/bin/git config --local --unset-all http.https://github.com/.extraheader
+Auto Release	Post Run actions/checkout@v4	2026-01-08T18:50:24.3574849Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+Auto Release	Post Run actions/checkout@v4	2026-01-08T18:50:24.3809321Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+Auto Release	Post Run actions/checkout@v4	2026-01-08T18:50:24.3844500Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+Auto Release	Complete job	﻿2026-01-08T18:50:24.4188983Z Cleaning up orphan processes

--- a/experiments/test-lino-arguments-fixed.mjs
+++ b/experiments/test-lino-arguments-fixed.mjs
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+
+// Test lino-arguments library parsing with version(false) fix
+
+console.log('process.argv:', process.argv);
+
+const { use } = eval(
+  await (await fetch('https://unpkg.com/use-m/use.js')).text()
+);
+
+const { makeConfig } = await use('lino-arguments');
+
+const config = makeConfig({
+  yargs: ({ yargs, getenv }) =>
+    yargs
+      .version(false) // Disable built-in --version handling
+      .option('version', {
+        type: 'string',
+        default: getenv('VERSION', ''),
+        describe: 'Version number',
+      })
+      .option('repository', {
+        type: 'string',
+        default: getenv('REPOSITORY', ''),
+        describe: 'GitHub repository',
+      })
+      .option('tag-prefix', {
+        type: 'string',
+        default: getenv('TAG_PREFIX', 'rust-v'),
+        describe: 'Tag prefix for the release',
+      }),
+});
+
+console.log('Parsed config:', JSON.stringify(config, null, 2));
+console.log('version:', config.version);
+console.log('repository:', config.repository);
+console.log('tagPrefix:', config.tagPrefix);

--- a/experiments/test-lino-arguments.mjs
+++ b/experiments/test-lino-arguments.mjs
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+
+// Test lino-arguments library parsing
+
+console.log('process.argv:', process.argv);
+
+const { use } = eval(
+  await (await fetch('https://unpkg.com/use-m/use.js')).text()
+);
+
+const { makeConfig } = await use('lino-arguments');
+
+const config = makeConfig({
+  yargs: ({ yargs, getenv }) =>
+    yargs
+      .option('version', {
+        type: 'string',
+        default: getenv('VERSION', ''),
+        describe: 'Version number',
+      })
+      .option('repository', {
+        type: 'string',
+        default: getenv('REPOSITORY', ''),
+        describe: 'GitHub repository',
+      })
+      .option('tag-prefix', {
+        type: 'string',
+        default: getenv('TAG_PREFIX', 'rust-v'),
+        describe: 'Tag prefix for the release',
+      }),
+});
+
+console.log('Parsed config:', JSON.stringify(config, null, 2));
+console.log('version:', config.version);
+console.log('repository:', config.repository);
+console.log('tagPrefix:', config.tagPrefix);

--- a/rust/scripts/collect-changelog.mjs
+++ b/rust/scripts/collect-changelog.mjs
@@ -24,7 +24,9 @@ const { makeConfig } = await use('lino-arguments');
 // Parse CLI arguments using lino-arguments
 const config = makeConfig({
   yargs: ({ yargs, getenv }) =>
-    yargs.option('version', {
+    yargs
+      .version(false) // Disable yargs built-in --version to use our custom version option
+      .option('version', {
       type: 'string',
       default: getenv('VERSION', ''),
       describe: 'Version to use in the changelog entry',

--- a/rust/scripts/create-github-release.mjs
+++ b/rust/scripts/create-github-release.mjs
@@ -28,6 +28,7 @@ const { makeConfig } = await use('lino-arguments');
 const config = makeConfig({
   yargs: ({ yargs, getenv }) =>
     yargs
+      .version(false) // Disable yargs built-in --version to use our custom version option
       .option('version', {
         type: 'string',
         default: getenv('VERSION', ''),


### PR DESCRIPTION
## Summary

The Rust CI/CD pipeline was failing during the "Auto Release" phase because the `create-github-release.mjs` script could not parse the `--version` command-line argument correctly.

## Root Cause

`"version"` is a reserved word in [yargs](https://yargs.js.org/) (v17.2.0+), the CLI argument parsing library used by `lino-arguments`. When a custom `--version` option is defined without disabling the built-in handling, yargs interprets it as a built-in version display command and returns `false` instead of the actual argument value.

This caused the script to fail with "Missing required arguments" even though the version was correctly passed.

## Solution

Add `.version(false)` before defining the custom `version` option to disable yargs' built-in `--version` handling:

```javascript
const config = makeConfig({
  yargs: ({ yargs, getenv }) =>
    yargs
      .version(false) // Disable yargs built-in --version handling
      .option('version', {
        type: 'string',
        default: getenv('VERSION', ''),
        describe: 'Version number',
      })
      // ... other options
});
```

## Changes

### Fixed Scripts (3 files)
- `rust/scripts/create-github-release.mjs` - **Primary failure point**
- `rust/scripts/collect-changelog.mjs` - Same issue potential
- `csharp/scripts/create-github-release.mjs` - Same issue potential

### Documentation (Case Study)
- `docs/case-studies/issue-22/README.md` - Detailed case study with root cause analysis
- `docs/case-studies/issue-22/ci-run-20828012412.txt` - Full CI logs from the failed run

### Experiment Scripts
- `experiments/test-lino-arguments.mjs` - Demonstrates the bug
- `experiments/test-lino-arguments-fixed.mjs` - Demonstrates the fix

## Testing

Verified locally that the fix works:

```bash
# Before (returns false)
node test-lino-arguments.mjs --version "0.2.0"
# version: false

# After (returns correct value)
node test-lino-arguments-fixed.mjs --version "0.2.0"
# version: 0.2.0
```

## References

- [yargs/yargs#2064 - Cannot have version as both option and command](https://github.com/yargs/yargs/issues/2064)
- [yargs version() documentation](https://yargs.js.org/docs/#api-reference-version)
- [CycloneDX/cdxgen#83 - Warning: "version" is a reserved word](https://github.com/CycloneDX/cdxgen/issues/83)

## Test Plan

- [x] Verified fix works locally with test scripts
- [x] All 3 affected scripts updated
- [ ] CI passes on this PR
- [ ] Rust release workflow succeeds

Fixes #22

---
*This PR was created automatically by the AI issue solver*