### PR TITLE
feat(rust): support both CARGO_REGISTRY_TOKEN and CARGO_TOKEN for publishing

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -326,10 +326,10 @@ jobs:
         if: steps.version_check.outputs.should_release == 'true'
         working-directory: ./rust
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN || secrets.CARGO_TOKEN }}
         run: |
           if [ -z "$CARGO_REGISTRY_TOKEN" ]; then
-            echo "::warning::CARGO_REGISTRY_TOKEN not set, skipping publish to crates.io"
+            echo "::warning::Neither CARGO_REGISTRY_TOKEN nor CARGO_TOKEN is set, skipping publish to crates.io"
           else
             cargo publish
           fi
@@ -397,10 +397,10 @@ jobs:
         if: steps.version.outputs.version_committed == 'true' || steps.version.outputs.already_released == 'true'
         working-directory: ./rust
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN || secrets.CARGO_TOKEN }}
         run: |
           if [ -z "$CARGO_REGISTRY_TOKEN" ]; then
-            echo "::warning::CARGO_REGISTRY_TOKEN not set, skipping publish to crates.io"
+            echo "::warning::Neither CARGO_REGISTRY_TOKEN nor CARGO_TOKEN is set, skipping publish to crates.io"
           else
             cargo publish
           fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/link-foundation/lino-objects-codec/issues/19
-Your prepared branch: issue-19-d88ab983ff7d
-Your prepared working directory: /tmp/gh-issue-solver-1767902341678
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/link-foundation/lino-objects-codec/issues/19
+Your prepared branch: issue-19-d88ab983ff7d
+Your prepared working directory: /tmp/gh-issue-solver-1767902341678
+
+Proceed.


### PR DESCRIPTION
## Summary
- Add support for `CARGO_TOKEN` as an alternative to `CARGO_REGISTRY_TOKEN` for crates.io publishing
- Use fallback logic: `${{ secrets.CARGO_REGISTRY_TOKEN || secrets.CARGO_TOKEN }}`
- Update warning message to indicate both possible token names when neither is set

## Changes
- Updated `auto-release` job to accept either token
- Updated `manual-release` job to accept either token

## Test plan
- [x] Workflow syntax validation (pushing triggers workflow)
- [x] Verify the workflow runs correctly with the updated configuration
- [ ] Verify publishing works when `CARGO_TOKEN` secret is set

Fixes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)