### PR TITLE
docs(readme): document built-in references for cycles, drop legacy (ref X)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-03T13:00:30.434Z for PR creation at branch issue-27-eb86cc75f92a for issue https://github.com/link-foundation/lino-objects-codec/issues/27

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-03T13:00:30.434Z for PR creation at branch issue-27-eb86cc75f92a for issue https://github.com/link-foundation/lino-objects-codec/issues/27

--- a/js/.changeset/issue-27-builtin-references.md
+++ b/js/.changeset/issue-27-builtin-references.md
@@ -1,0 +1,9 @@
+---
+'lino-objects-codec': patch
+---
+
+Document the built-in references format for circular references and add
+regression tests that lock it in. The encoder already emits cycles as bare
+`obj_N` links inside an `(obj_N: type ...)` self-reference definition, but the
+README still showed the legacy `(ref obj_N)` marker. README, regression tests,
+and the format-invariant assertions are now consistent. See issue #27.

--- a/js/README.md
+++ b/js/README.md
@@ -251,8 +251,15 @@ The library uses the [links-notation](https://github.com/link-foundation/links-n
 
 - Basic types are encoded with type markers: `(int 42)`, `(str "hello")`, `(bool true)`
 - Strings are base64-encoded to handle special characters and newlines
-- Collections include object IDs for reference tracking: `(array obj_0 item1 item2 ...)`
-- Circular references use special `ref` links: `(ref obj_0)`
+- Shared / cyclic collections are defined inline with a self-reference id using
+  the built-in links-notation `(self-ref: first-ref second-ref ...)` form, e.g.
+  `(obj_0: array (int 1) (int 2) ...)` or `(obj_0: object (key val) ...)`
+- Circular references use built-in links-notation references — the bare object
+  id link `obj_0` — instead of a dedicated keyword. For example, a self-
+  referencing object `{ self: obj }` encodes as
+  `(obj_0: object ((str c2VsZg==) obj_0))` (no `(ref obj_0)` marker). See
+  [issue #27](https://github.com/link-foundation/lino-objects-codec/issues/27)
+  for the rationale.
 
 This approach allows for:
 

--- a/js/tests/test_circular_references.test.js
+++ b/js/tests/test_circular_references.test.js
@@ -240,3 +240,42 @@ test('array and object circular reference', () => {
   assert.equal(decoded.arr[0], 1);
   assert.equal(decoded.arr[1], decoded); // Circular reference
 });
+
+// Tests for the encoded format itself: circular references must use built-in
+// links-notation references (a bare `obj_N` link) rather than the legacy
+// `(ref obj_N)` marker. See issue #27.
+test('encoded format uses built-in references, not (ref X) marker', () => {
+  const obj = {};
+  obj.self = obj;
+  const encoded = encode({ obj });
+
+  // Self-reference should appear as a bare `obj_0` link, not wrapped in (ref ...)
+  assert.match(
+    encoded,
+    /obj_0/,
+    `expected encoded output to contain bare obj_0 reference, got: ${encoded}`
+  );
+  assert.doesNotMatch(
+    encoded,
+    /\(ref\b/,
+    `expected encoded output to NOT contain (ref ...) marker, got: ${encoded}`
+  );
+
+  // The self-referenced object must be defined inline using the
+  // `(obj_id: type ...)` form, not `(type obj_id ...)`.
+  assert.match(
+    encoded,
+    /\(obj_0:\s*object\b/,
+    `expected (obj_0: object ...) self-reference definition, got: ${encoded}`
+  );
+});
+
+test('decoder rejects legacy (ref X) marker as unknown type', () => {
+  // The legacy form must no longer be supported as a type marker. Decoding
+  // should fail loudly so it cannot silently masquerade as a real type.
+  const legacy = '(object obj_0 ((str c2VsZg==) (ref obj_0)))';
+  assert.throws(
+    () => decode({ notation: legacy }),
+    /Unknown type marker:\s*ref/
+  );
+});

--- a/python/README.md
+++ b/python/README.md
@@ -152,8 +152,15 @@ The library uses the [links-notation](https://github.com/link-foundation/links-n
 
 - Basic types are encoded with type markers: `(int 42)`, `(str "hello")`, `(bool True)`
 - Strings are base64-encoded to handle special characters and newlines
-- Collections include object IDs for reference tracking: `(list obj_0 item1 item2 ...)`
-- Circular references use special `ref` links: `(ref obj_0)`
+- Shared / cyclic collections are defined inline with a self-reference id using
+  the built-in links-notation `(self-ref: first-ref second-ref ...)` form, e.g.
+  `(obj_0: list (int 1) (int 2) ...)` or `(obj_0: dict (key val) ...)`
+- Circular references use built-in links-notation references — the bare object
+  id link `obj_0` — instead of a dedicated keyword. For example, a self-
+  referencing dict `{"self": obj}` encodes as
+  `(obj_0: dict ((str c2VsZg==) obj_0))` (no `(ref obj_0)` marker). See
+  [issue #27](https://github.com/link-foundation/lino-objects-codec/issues/27)
+  for the rationale.
 
 This approach allows for:
 - Universal representation of object graphs

--- a/python/changelog.d/20260503_issue_27_builtin_references.md
+++ b/python/changelog.d/20260503_issue_27_builtin_references.md
@@ -1,0 +1,8 @@
+### Changed
+
+- Document the built-in references format for circular references in the Python
+  README. The encoder already produces `(obj_N: dict ...)` / `(obj_N: list ...)`
+  self-reference definitions and bare `obj_N` back-references; the README now
+  matches and explicitly notes that the legacy `(ref obj_N)` marker is no
+  longer recognized. Regression tests lock in the new format. See
+  [issue #27](https://github.com/link-foundation/lino-objects-codec/issues/27).

--- a/python/tests/test_circular_references.py
+++ b/python/tests/test_circular_references.py
@@ -1,5 +1,7 @@
 """Tests for encoding/decoding objects with circular references."""
 
+import pytest
+
 from link_notation_objects_codec import decode, encode
 
 
@@ -150,3 +152,21 @@ class TestCircularReferences:
         assert decoded["child"]["child"]["child"]["level"] == 4
         # Check circular reference back to root
         assert decoded["child"]["child"]["child"]["root"] is decoded
+
+    def test_encoded_format_uses_builtin_references_not_ref_marker(self):
+        """Cycles must encode as bare `obj_N` links, not `(ref obj_N)`. See issue #27."""
+        d = {}
+        d["self"] = d
+        encoded = encode(d)
+
+        # Self-reference must be a bare obj_0 link, not a (ref ...) wrapper.
+        assert "obj_0" in encoded, encoded
+        assert "(ref " not in encoded, encoded
+        # The owner must be defined inline using the (obj_id: type ...) form.
+        assert "(obj_0: dict" in encoded, encoded
+
+    def test_decoder_rejects_legacy_ref_marker(self):
+        """Legacy (ref X) form must be rejected as an unknown type marker."""
+        legacy = "(dict obj_0 ((str c2VsZg==) (ref obj_0)))"
+        with pytest.raises(ValueError, match=r"Unknown type marker:\s*ref"):
+            decode(legacy)


### PR DESCRIPTION
## Summary

Closes #27.

The encoder in both JS and Python already emits circular references using
the built-in links-notation self-reference form
`(self-ref: first-ref second-ref ...)` rather than a `(ref obj_N)` marker.
For example, `{ self: obj }` encodes as
`(obj_0: object ((str c2VsZg==) obj_0))` (JS) or
`(obj_0: dict ((str c2VsZg==) obj_0))` (Python). Decoders in both languages
already reject `(ref X)` as an unknown type marker.

The per-language READMEs still documented the legacy `(ref obj_0)` syntax
in their "How It Works" sections, which contradicted both the emitted
format and the main `README.md` (which already documented the new style).
This PR makes the per-language docs match reality and adds regression
tests that lock in the format invariant.

## Changes

- `js/README.md`, `python/README.md`: replace the stale
  `(ref obj_0)` / `(list obj_0 ...)` description with the actual
  `(obj_0: dict ...)` / `(obj_0: list ...)` self-reference form, and
  link to #27 for context.
- `js/tests/test_circular_references.test.js`,
  `python/tests/test_circular_references.py`: two new regression tests
  per language asserting:
  1. cycles encode as bare `obj_N` links inside an `(obj_N: type ...)`
     self-reference definition (the encoded string contains no
     `(ref ` substring);
  2. the legacy `(ref X)` form fails to decode with
     `Unknown type marker: ref`, so it cannot silently masquerade as a
     real type marker.
- `js/.changeset/issue-27-builtin-references.md`: patch changeset
  (docs + tests, no source changes).
- `python/changelog.d/20260503_issue_27_builtin_references.md`:
  matching scriv fragment.
- `.gitkeep`: removed (placeholder from PR-init now superseded by real
  changes).

## Test plan

- [x] `cd js && npm test` — 146 passed (was 144; +2 new regression tests)
- [x] `cd js && npm run lint && npm run format:check` — clean (only
      pre-existing complexity warnings in `src/codec.js` and
      `src/format.js`)
- [x] `cd python && pytest tests/ --no-cov` — 73 passed (was 71;
      +2 new regression tests)
- [x] `cd python && ruff check src tests && ruff format --check src tests
      && mypy src` — all clean
- [x] Manually verified encoder output for self-references, mutual
      references, and shared sub-objects in both JS and Python — all
      use `obj_N` direct references, none use `(ref ...)`.

## Issue reproduction

The example from the issue:

```js
const obj = { self: obj, other: { '1': 1, '2': 2 } };
```

now produces (and is documented to produce):

```
(obj_0: object ((str c2VsZg==) obj_0) ((str b3RoZXI=) (object ((str MQ==) (int 1)) ((str Mg==) (int 2)))))
```

— exactly the built-in self-reference form requested in the issue, with
no `ref` keyword.